### PR TITLE
Fixed a bug in the e2e app test where it referenced the wrong module

### DIFF
--- a/src/application/files/test/app.e2e-spec.ts
+++ b/src/application/files/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { Test } from '@nestjs/testing';
-import { AppModule } from './../src/app.module';
+import { ApplicationModule } from './../src/app.module';
 import { INestApplication } from '@nestjs/common';
 
 describe('AppController (e2e)', () => {
@@ -8,7 +8,7 @@ describe('AppController (e2e)', () => {
 
   beforeAll(async () => {
     const moduleFixture = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [ApplicationModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();


### PR DESCRIPTION
Let me know if this is the wrong branch to PR against, I can see you have a couple RC versions on the go. Maybe it's even been fixed but right now the e2e can't run because the test file tries to import `AppModule` as opposed to `ApplicationModule`