### PR TITLE
Allows npm to publish gitignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 .idea/
 
 .git/
-.gitignore
+/.gitignore
 
 .dockerignore
 Dockerfile


### PR DESCRIPTION
The current `.npmignore` prevents the publication of any of the `.gitignore` files contained in the templates.

Adding a `/` at the beginning of a rule in `.npmignore` (as in `.gitignore`) restricts the rule to the root level and allows the templates to be published including the `.gitignore` files.