### PR TITLE
Enables simpler HMR config for development

### DIFF
--- a/src/templates/ts/application/README.md
+++ b/src/templates/ts/application/README.md
@@ -16,8 +16,11 @@ $ <%= packageManager %> install
 # development
 $ <%= packageManager %> run start
 
-# watch mode
+# watch mode (with [nodemon](https://nodemon.io/))
 $ <%= packageManager %> run start:dev
+
+# watch mode (with Webpack and Hot Reload enabled)
+$ <%= packageManager %> run start:hmr
 
 # production mode
 <%= packageManager %> run start:prod

--- a/src/templates/ts/application/package.json
+++ b/src/templates/ts/application/package.json
@@ -10,11 +10,10 @@
     "start:dev": "nodemon",
     "prestart:prod": "rm -rf dist && tsc",
     "start:prod": "node dist/main.js",
-    "start:hmr": "node dist/server",
+    "start:hmr": "webpack --config webpack.config.js",
     "test": "jest",
     "test:cov": "jest --coverage",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
-    "webpack": "webpack --config webpack.config.js"
+    "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^5.0.0",
@@ -43,7 +42,8 @@
     "tslint": "5.3.2",
     "webpack": "^4.2.0",
     "webpack-cli": "^2.0.13",
-    "webpack-node-externals": "^1.6.0"
+    "webpack-node-externals": "^1.6.0",
+    "webpack-spawn-plugin": "^0.2.1"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/templates/ts/application/webpack.config.js
+++ b/src/templates/ts/application/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
+const SpawnPlugin = require('webpack-spawn-plugin');
 
 module.exports = {
   entry: ['webpack/hot/poll?1000', './src/main.hmr.ts'],
@@ -26,6 +27,7 @@ module.exports = {
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
+    new SpawnPlugin('node', ['dist/server'], { persistent: true })
   ],
   output: {
     path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
Currently, the application template in TypeScript offers 3 ways to serve an app in development, the most promising one being WebPack+HMR, but it is also the less convenient to setup (it requires 2 terminals).

This PR simplifies the setup of the WebPack+HMR dev env for Nest by inntroducing the usage of the WebPack addon `webpack-spawn-plugin`, and by letting Webpack run the server.