### PR TITLE
move rimraf package to dependencies

### DIFF
--- a/src/templates/ts/application/package.json
+++ b/src/templates/ts/application/package.json
@@ -25,6 +25,7 @@
     "@nestjs/microservices": "^5.1.0", <% } %><% if (dependencies.indexOf('websockets') !== -1) { %>
     "@nestjs/websockets": "^5.1.0", <% } %>
     "reflect-metadata": "^0.1.12",
+    "rimraf": "^2.6.2",
     "rxjs": "^6.2.2",
     "typescript": "^3.0.1"
   },
@@ -37,7 +38,6 @@
     "jest": "^23.5.0",
     "nodemon": "^1.18.3",
     "prettier": "^1.14.2",
-    "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
     "ts-jest": "^23.1.3",
     "ts-loader": "^4.4.2",


### PR DESCRIPTION
When I set ```NODE_ENV=production``` the package rimraf will not be installed, running ```npm run start:prod``` the script fail because rimraf it not installed.

Move rimraf package to dependencies to install in production enviroment.