### PR TITLE
fix: ignore dist folder for better auto importing intellisense

### DIFF
--- a/src/lib/application/files/js/jsconfig.json
+++ b/src/lib/application/files/js/jsconfig.json
@@ -4,6 +4,7 @@
       "experimentalDecorators": true
   },
   "exclude": [
-      "node_modules"
+      "node_modules",
+      "dist"
   ]
 }

--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -11,5 +11,5 @@
     "baseUrl": "./",
     "incremental": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
VSCode auto import always show intellisense or automatically import from the `dist` folder 

![image](https://user-images.githubusercontent.com/10440327/59996230-acf89380-9651-11e9-8a4b-3cc4e5e5ea21.png)



Issue Number: N/A


## What is the new behavior?
Auto import of missing imports and intellisense is ignoring `dist` folder
![image](https://user-images.githubusercontent.com/10440327/59996264-ca2d6200-9651-11e9-93ae-729ef5186d5f.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

related to https://github.com/Microsoft/vscode/issues/40248