### PR TITLE
fix: remove typescript as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/schematics",
-  "version": "6.4.1",
+  "version": "6.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7627,9 +7627,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg=="
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular-devkit/core": "8.2.1",
     "@angular-devkit/schematics": "8.2.1",
     "ts-morph": "^3.0.0",
-    "typescript": "^3.2.2"
+    "typescript": "3.4.5"
   },
   "devDependencies": {
     "@types/jest": "23.3.14",
@@ -39,8 +39,7 @@
     "jest": "24.8.0",
     "nyc": "14.1.1",
     "ts-jest": "24.0.2",
-    "tslint": "5.18.0",
-    "typescript": "3.4.5"
+    "tslint": "5.18.0"
   },
   "schematics": "./collection.json",
   "nyc": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Typescript is added as dependency and devDpendecny both, which generates warning.
Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information