### PR TITLE
Matches on "from" instead of "import" to avoid breakage of multi-line imports

### DIFF
--- a/test/utils/module-import.declarator.test.ts
+++ b/test/utils/module-import.declarator.test.ts
@@ -26,6 +26,7 @@ describe('Module Import Declarator', () => {
       'export class FooModule {}\n'
     );
   });
+
   it('should manage no type', () => {
     const content: string =
       'import { Module } from \'@nestjs/common\';\n' +
@@ -45,6 +46,74 @@ describe('Module Import Declarator', () => {
       'import { Foo } from \'./foo\';\n' +
       '\n' +
       '@Module({})\n' +
+      'export class FooModule {}\n'
+    );
+  });
+
+  it('should not break existing multi-line imports', () => {
+    const content: string =
+      'import {\n' +
+      '  Module,\n' +
+      '  Helper,\n' +
+      '} from \'@nestjs/common\';\n' +
+      '\n' +
+      '@Helper()\n' +
+      '@Module({})\n' +
+      'export class FooModule {}\n';
+    const options: DeclarationOptions = {
+      metadata: 'imports',
+      type: 'module',
+      name: 'bar',
+      path: normalize('/src/foo/bar'),
+      module: normalize('/src/foo/foo.module.ts'),
+      symbol: 'BarModule'
+    };
+    const declarator = new ModuleImportDeclarator();
+    expect(declarator.declare(content, options)).toEqual(
+      'import {\n' +
+      '  Module,\n' +
+      '  Helper,\n' +
+      '} from \'@nestjs/common\';\n' +
+      'import { BarModule } from \'./bar/bar.module\';\n' +
+      '\n' +
+      '@Helper()\n' +
+      '@Module({})\n' +
+      'export class FooModule {}\n'
+    );
+  });
+
+  it('should not break on match of "from" in other contexts', () => {
+    const content: string =
+      'import {\n' +
+      '  Module,\n' +
+      '  Helper,\n' +
+      '} from \'@nestjs/common\';\n' +
+      '\n' +
+      '@Helper()\n' +
+      '@Module({})\n' +
+      'const x = " from ";\n' +
+      'console.error(" from ");\n' +
+      'export class FooModule {}\n';
+    const options: DeclarationOptions = {
+      metadata: 'imports',
+      type: 'module',
+      name: 'bar',
+      path: normalize('/src/foo/bar'),
+      module: normalize('/src/foo/foo.module.ts'),
+      symbol: 'BarModule'
+    };
+    const declarator = new ModuleImportDeclarator();
+    expect(declarator.declare(content, options)).toEqual(
+      'import {\n' +
+      '  Module,\n' +
+      '  Helper,\n' +
+      '} from \'@nestjs/common\';\n' +
+      'import { BarModule } from \'./bar/bar.module\';\n' +
+      '\n' +
+      '@Helper()\n' +
+      '@Module({})\n' +
+      'const x = " from ";\n' +
+      'console.error(" from ");\n' +
       'export class FooModule {}\n'
     );
   });


### PR DESCRIPTION
Also, changes the algorithm to insert generated import stamtement
via Array#splice instead of using concat on multiple arrays.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~Docs have been added / updated (for bug fixes / features)~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #204 


## What is the new behavior?
No new behavior is introduced. Instead, the previously intended behavior of allowing for multi-line imports is now supported.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information