### PR TITLE
fix(schema) change angular target version to auto

### DIFF
--- a/src/lib/client-app/angular/angular.factory.ts
+++ b/src/lib/client-app/angular/angular.factory.ts
@@ -41,7 +41,7 @@ export function main(options: AngularOptions): Rule {
   };
 }
 
-function transform(source: AngularOptions): ModuleOptions {
+function transform(source: AngularOptions): ModuleOptions & AngularOptions {
   const target: AngularOptions = Object.assign({}, source);
   target.directory = target.name ? strings.dasherize(target.name) : 'client';
   target.name = 'Angular';

--- a/src/lib/client-app/angular/angular.schema.d.ts
+++ b/src/lib/client-app/angular/angular.schema.d.ts
@@ -6,6 +6,10 @@ export interface AngularOptions {
    */
   name: string;
   /**
+   * Angular version.
+   */
+  version: string;
+  /**
    * The directory of the application.
    */
   directory?: string;

--- a/src/lib/client-app/angular/schema.json
+++ b/src/lib/client-app/angular/schema.json
@@ -18,7 +18,15 @@
         "index": 0
       },
       "x-prompt": "What name would you like to (or do you) use for Angular application?"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of the Angular CLI to use.",
+      "visible": false,
+      "$default": {
+        "$source": "ng-cli-version"
+      }
     }
   },
-  "required": ["name"]
+  "required": ["name", "version"]
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #241 


## What is the new behavior?
Based on https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/ng-new/schema.json

Now the schema of the schematic ng-new is executing a command in order to get angular's global version.

This is agnostic to the package manager (NPM or YARN)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information