### PR TITLE
fix(): update decorator schematic to use SetMetadata over deprecated …

### DIFF
--- a/src/lib/decorator/decorator.factory.test.ts
+++ b/src/lib/decorator/decorator.factory.test.ts
@@ -21,9 +21,9 @@ describe('Decorator Factory', () => {
       files.find(filename => filename === '/foo/foo.decorator.ts'),
     ).not.toBeUndefined();
     expect(tree.readContent('/foo/foo.decorator.ts')).toEqual(
-      "import { ReflectMetadata } from '@nestjs/common';\n" +
+      "import { SetMetadata } from '@nestjs/common';\n" +
         '\n' +
-        "export const Foo = (...args: string[]) => ReflectMetadata('foo', args);\n",
+        "export const Foo = (...args: string[]) => SetMetadata('foo', args);\n",
     );
   });
   it('should manage name as a path', () => {
@@ -37,9 +37,9 @@ describe('Decorator Factory', () => {
       files.find(filename => filename === '/bar/foo/foo.decorator.ts'),
     ).not.toBeUndefined();
     expect(tree.readContent('/bar/foo/foo.decorator.ts')).toEqual(
-      "import { ReflectMetadata } from '@nestjs/common';\n" +
+      "import { SetMetadata } from '@nestjs/common';\n" +
         '\n' +
-        "export const Foo = (...args: string[]) => ReflectMetadata('foo', args);\n",
+        "export const Foo = (...args: string[]) => SetMetadata('foo', args);\n",
     );
   });
   it('should manage name and path', () => {
@@ -54,9 +54,9 @@ describe('Decorator Factory', () => {
       files.find(filename => filename === '/baz/foo/foo.decorator.ts'),
     ).not.toBeUndefined();
     expect(tree.readContent('/baz/foo/foo.decorator.ts')).toEqual(
-      "import { ReflectMetadata } from '@nestjs/common';\n" +
+      "import { SetMetadata } from '@nestjs/common';\n" +
         '\n' +
-        "export const Foo = (...args: string[]) => ReflectMetadata('foo', args);\n",
+        "export const Foo = (...args: string[]) => SetMetadata('foo', args);\n",
     );
   });
   it('should manage name to dasherize', () => {
@@ -70,9 +70,9 @@ describe('Decorator Factory', () => {
       files.find(filename => filename === '/foo-bar/foo-bar.decorator.ts'),
     ).not.toBeUndefined();
     expect(tree.readContent('/foo-bar/foo-bar.decorator.ts')).toEqual(
-      "import { ReflectMetadata } from '@nestjs/common';\n" +
+      "import { SetMetadata } from '@nestjs/common';\n" +
         '\n' +
-        "export const FooBar = (...args: string[]) => ReflectMetadata('foo-bar', args);\n",
+        "export const FooBar = (...args: string[]) => SetMetadata('foo-bar', args);\n",
     );
   });
   it('should manage path to dasherize', () => {
@@ -86,9 +86,9 @@ describe('Decorator Factory', () => {
       files.find(filename => filename === '/bar-baz/foo/foo.decorator.ts'),
     ).not.toBeUndefined();
     expect(tree.readContent('/bar-baz/foo/foo.decorator.ts')).toEqual(
-      "import { ReflectMetadata } from '@nestjs/common';\n" +
+      "import { SetMetadata } from '@nestjs/common';\n" +
         '\n' +
-        "export const Foo = (...args: string[]) => ReflectMetadata('foo', args);\n",
+        "export const Foo = (...args: string[]) => SetMetadata('foo', args);\n",
     );
   });
   it('should manage javascript file', () => {
@@ -103,9 +103,9 @@ describe('Decorator Factory', () => {
       files.find(filename => filename === '/foo/foo.decorator.js'),
     ).not.toBeUndefined();
     expect(tree.readContent('/foo/foo.decorator.js')).toEqual(
-      "import { ReflectMetadata } from '@nestjs/common';\n" +
+      "import { SetMetadata } from '@nestjs/common';\n" +
         '\n' +
-        "export const Foo = (...args) => ReflectMetadata('foo', args);\n",
+        "export const Foo = (...args) => SetMetadata('foo', args);\n",
     );
   });
 });

--- a/src/lib/decorator/files/js/__name__.decorator.js
+++ b/src/lib/decorator/files/js/__name__.decorator.js
@@ -1,3 +1,3 @@
-import { ReflectMetadata } from '@nestjs/common';
+import { SetMetadata } from '@nestjs/common';
 
-export const <%= classify(name) %> = (...args) => ReflectMetadata('<%= name %>', args);
+export const <%= classify(name) %> = (...args) => SetMetadata('<%= name %>', args);

--- a/src/lib/decorator/files/ts/__name__.decorator.ts
+++ b/src/lib/decorator/files/ts/__name__.decorator.ts
@@ -1,3 +1,3 @@
-import { ReflectMetadata } from '@nestjs/common';
+import { SetMetadata } from '@nestjs/common';
 
-export const <%= classify(name) %> = (...args: string[]) => ReflectMetadata('<%= name %>', args);
+export const <%= classify(name) %> = (...args: string[]) => SetMetadata('<%= name %>', args);


### PR DESCRIPTION
…ReflectMetadata

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The decorator schematic currently uses ReflectMetadata, which adds deprecated messages to the console when running Nest. 

Issue Number: N/A


## What is the new behavior?
Updated to use SetMetadata, which is what the CLI suggests to use instead.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information