### PR TITLE
Added jest-runner-groups to manage test groups

### DIFF
--- a/src/lib/application/application.factory.test.ts
+++ b/src/lib/application/application.factory.test.ts
@@ -30,8 +30,7 @@ describe('Application Factory', () => {
       '/project/src/app.module.ts',
       '/project/src/app.service.ts',
       '/project/src/main.ts',
-      '/project/test/app.e2e-spec.ts',
-      '/project/test/jest-e2e.json',
+      '/project/test/e2e/app.spec.ts',
     ]);
   });
   it('should manage name to dasherize', () => {
@@ -54,8 +53,7 @@ describe('Application Factory', () => {
       '/awesome-project/src/app.module.ts',
       '/awesome-project/src/app.service.ts',
       '/awesome-project/src/main.ts',
-      '/awesome-project/test/app.e2e-spec.ts',
-      '/awesome-project/test/jest-e2e.json',
+      '/awesome-project/test/e2e/app.spec.ts',
     ]);
   });
   it('should manage javascript files', () => {
@@ -80,8 +78,7 @@ describe('Application Factory', () => {
       '/project/src/app.module.js',
       '/project/src/app.service.js',
       '/project/src/main.js',
-      '/project/test/app.e2e-spec.js',
-      '/project/test/jest-e2e.json',
+      '/project/test/e2e/app.spec.js',
     ]);
   });
 });

--- a/src/lib/application/files/js/package.json
+++ b/src/lib/application/files/js/package.json
@@ -8,9 +8,9 @@
     "format": "prettier --write \"**/*.js\"",
     "start": "babel-node index.js",
     "start:dev": "nodemon",
-    "test": "jest",
+    "test": "jest --group=functional --group=unit",
     "test:cov": "jest --coverage",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --group=e2e"
   },
   "dependencies": {
     "@nestjs/common": "^6.7.2",
@@ -29,6 +29,7 @@
     "@babel/register": "^7.6.2",
     "@babel/runtime": "^7.6.2",
     "jest": "^24.9.0",
+    "jest-runner-groups": "^1.0.0",
     "nodemon": "^1.19.2",
     "prettier": "^1.18.2",
     "supertest": "^4.0.2"
@@ -38,7 +39,11 @@
       "js",
       "json"
     ],
-    "rootDir": "src",
+    "roots": [
+      "<rootDir>/src/",
+      "<rootDir>/test/"
+    ],
+    "runner": "groups",
     "testRegex": ".spec.js$",
     "coverageDirectory": "./coverage"
   }

--- a/src/lib/application/files/js/src/app.controller.spec.js
+++ b/src/lib/application/files/js/src/app.controller.spec.js
@@ -1,3 +1,9 @@
+/**
+ * Tests AppController class.
+ * 
+ * @group functional/App/AppController
+ */
+
 import { Test } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';

--- a/src/lib/application/files/js/test/e2e/app.spec.js
+++ b/src/lib/application/files/js/test/e2e/app.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Tests app controller.
+ * 
+ * @group supertest
+ * @group e2e/App/AppController
+ */
+
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from '../src/app.module';

--- a/src/lib/application/files/js/test/e2e/app.spec.js
+++ b/src/lib/application/files/js/test/e2e/app.spec.js
@@ -7,7 +7,7 @@
 
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
-import { AppModule } from '../src/app.module';
+import { AppModule } from '../../src/app.module';
 
 describe('AppController (e2e)', () => {
   let app;

--- a/src/lib/application/files/js/test/jest-e2e.json
+++ b/src/lib/application/files/js/test/jest-e2e.json
@@ -1,5 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json"],
-  "rootDir": ".",
-  "testRegex": ".e2e-spec.js$"
-}

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -13,8 +13,8 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "tslint -p tsconfig.json -c tslint.json",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "jest --group=functional --group=unit",
+    "test:watch": "jest --watch --group=functional --group=unit",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --group=e2e"

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --group=e2e"
   },
   "dependencies": {
     "@nestjs/common": "^6.7.2",
@@ -36,6 +36,7 @@
     "@types/node": "^12.7.5",
     "@types/supertest": "^2.0.8",
     "jest": "^24.9.0",
+    "jest-runner-groups": "^1.0.0",
     "prettier": "^1.18.2",
     "supertest": "^4.0.2",
     "ts-jest": "^24.1.0",
@@ -51,7 +52,11 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "roots": [
+      "<rootDir>/src/",
+      "<rootDir>/test/"
+    ],
+    "runner": "groups",
     "testRegex": ".spec.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/src/lib/application/files/ts/src/app.controller.spec.ts
+++ b/src/lib/application/files/ts/src/app.controller.spec.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests AppController class.
+ * 
+ * @group functional/App/AppController
+ */
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';

--- a/src/lib/application/files/ts/test/e2e/app.spec.ts
+++ b/src/lib/application/files/ts/test/e2e/app.spec.ts
@@ -1,7 +1,14 @@
+/**
+ * Tests app controller.
+ * 
+ * @group supertest
+ * @group e2e/App/AppController
+ */
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from './../../src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;

--- a/src/lib/application/files/ts/test/jest-e2e.json
+++ b/src/lib/application/files/ts/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
-}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: **tests related changes**

## What is the current behavior?

Currently when a new project is generated, there are two configs for jest to run functional and e2e tests. Those configs are identical but the only difference is that it uses different root directories to search tests in. It is cumbersome to have two identical configs only to separate tests into groups and run it separately.


## What is the new behavior?

1. The [**jest-runner-groups**](https://github.com/eugene-manuilov/jest-runner-groups) dependency has been added to the dev dependencies list in the package.json file of the generated project
1. Jest configuration in the package.json file has been updated to match all tests (defined in src/ and test/ folders)
1. Jest config file in the test/ folder has been deleted
1. All test have been updated to have appropriate groups (`functional` for tests in the src/ folder, `e2e` for tests in the test/ folder).
1. Test script commands have been updated to use appropriate `--group=...` arguments.

So, now when a new project is generated, it creates test files with docblocks that include `@group` parameters to define to which group a test belongs. It helps to simplify tests grouping and eliminates a need to maintain two separate jest configs. 

Furthermore it allows developers to run only specific tests if they use fully qualified group names. For example, they can run `npm test -- --group=functional/App` to run tests marked with `@group functional/App/...`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information