### PR TITLE
feat(): add directory option to the application schematic

### DIFF
--- a/src/lib/application/application.factory.test.ts
+++ b/src/lib/application/application.factory.test.ts
@@ -84,4 +84,29 @@ describe('Application Factory', () => {
       '/project/test/jest-e2e.json',
     ]);
   });
+  it('should manage destination directory', () => {
+    const options: ApplicationOptions = {
+      name: '@scope/package',
+      directory: 'scope-package',
+    };
+    const tree: UnitTestTree = runner.runSchematic('application', options);
+    const files: string[] = tree.files;
+    expect(files).toEqual([
+      '/scope-package/.gitignore',
+      '/scope-package/.prettierrc',
+      '/scope-package/README.md',
+      '/scope-package/nest-cli.json',
+      '/scope-package/package.json',
+      '/scope-package/tsconfig.build.json',
+      '/scope-package/tsconfig.json',
+      '/scope-package/tslint.json',
+      '/scope-package/src/app.controller.spec.ts',
+      '/scope-package/src/app.controller.ts',
+      '/scope-package/src/app.module.ts',
+      '/scope-package/src/app.service.ts',
+      '/scope-package/src/main.ts',
+      '/scope-package/test/app.e2e-spec.ts',
+      '/scope-package/test/jest-e2e.json',
+    ]);
+  });
 });

--- a/src/lib/application/application.factory.ts
+++ b/src/lib/application/application.factory.ts
@@ -20,7 +20,7 @@ import { ApplicationOptions } from './application.schema';
 export function main(options: ApplicationOptions): Rule {
   options.name = strings.dasherize(options.name);
 
-  const path = options.name;
+  const path = options.directory || options.name;
   options = transform(options);
   return mergeWith(generate(options, path));
 }

--- a/src/lib/application/application.schema.d.ts
+++ b/src/lib/application/application.schema.d.ts
@@ -12,6 +12,10 @@ export interface ApplicationOptions {
    */
   description?: string;
   /**
+   * Nest application destination directory
+   */
+  directory?: string;
+  /**
    * Nest application version.
    */
   version?: string;

--- a/src/lib/application/schema.json
+++ b/src/lib/application/schema.json
@@ -23,6 +23,10 @@
       "description": "Nest application description.",
       "default": ""
     },
+    "directory": {
+      "type": "string",
+      "description": "Nest application destination directory"
+    },
     "version": {
       "type": "string",
       "description": "Nest application version.",


### PR DESCRIPTION
nestjs/nest-cli#283

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: nestjs/nest-cli#283
```
> nest new @scope/package
```
This command will generate application files inside the 'package' folder and additionally, it will put everything inside a wrapping folder '@scope'. Furthermore currently there is no option to generate the application to another directory than the same as the application name says.
## What is the new behavior?
```
> nest new @scope/package --directory=scope-package
```
This command will produce new application inside scope-package/

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information