### PR TITLE
chore(deps): upgrade dependencies typescript 4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14665,9 +14665,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.2.0.tgz",
-      "integrity": "sha512-9+y2qwzXdAImgLSYLXAb/Rhq9+K4rbt0417b8ai987V60g2uoNWBBmMkYgutI7D8Zhu+IbCSHbBtrHxB9d7xyA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.3.0.tgz",
+      "integrity": "sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -14817,9 +14817,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
     "jest": "26.4.2",
     "nyc": "15.1.0",
     "release-it": "^12.4.3",
-    "ts-jest": "26.2.0",
+    "ts-jest": "26.3.0",
     "ts-node": "9.0.0",
-    "typescript": "3.9.7"
+    "typescript": "4.0.2"
   },
   "peerDependencies": {
-    "typescript": "^3.4.5"
+    "typescript": ">= 3.4.5 < 5.0.0"
   },
   "schematics": "./dist/collection.json",
   "husky": {


### PR DESCRIPTION
* Including ts-jest 26.3.0 to remove warnings
* Make peer dep for ts in a range 3.4.5-5

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Update deps: typescript 4.0.2 + ts-jest 26.3.0
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information