### PR TITLE
fix(deps): Relax TypeScript peerDependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "3.9.7"
   },
   "peerDependencies": {
-    "typescript": "^3.4.5"
+    "typescript": ">=3.4.5"
   },
   "schematics": "./dist/collection.json",
   "husky": {


### PR DESCRIPTION
Support TypeScript v4 by relaxing peer dependency requirement.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

While using TypeScript 4, I receive the following warning on `yarn install`:

![image](https://user-images.githubusercontent.com/12538019/92762905-0c2eea80-f361-11ea-91a7-b8c16a5d8a64.png)

## What is the new behavior?

No warning on Yarn installs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information