### PR TITLE
feat(application): allow absolute import in test

### DIFF
--- a/src/lib/application/files/js/package.json
+++ b/src/lib/application/files/js/package.json
@@ -39,8 +39,15 @@
       "js",
       "json"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".spec.js$",
-    "coverageDirectory": "../coverage"
+    "coverageDirectory": "../coverage",
+    "moduleDirectories": [
+      "src",
+      "node_modules"
+    ],
+    "modulePaths": [
+      "."
+    ]
   }
 }

--- a/src/lib/application/files/js/test/jest-e2e.json
+++ b/src/lib/application/files/js/test/jest-e2e.json
@@ -1,5 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json"],
-  "rootDir": ".",
-  "testRegex": ".e2e-spec.js$"
+  "rootDir": "..",
+  "testRegex": ".e2e-spec.js$",
+  "moduleDirectories": ["src", "node_modules"],
+  "modulePaths": ["."]
 }

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -56,12 +56,19 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".spec.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleDirectories": [
+      "src",
+      "node_modules"
+    ],
+    "modulePaths": [
+      "."
+    ]
   }
 }

--- a/src/lib/application/files/ts/test/jest-e2e.json
+++ b/src/lib/application/files/ts/test/jest-e2e.json
@@ -1,9 +1,11 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "moduleDirectories": ["src", "node_modules"],
+  "modulePaths": ["."]
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

VsCode tends to auto import modules in `*.spec.ts` files using absolute path (relative to project root).
This behaviour can be configured in settings but I think it's worth to make absolute import work by default by tweaking jest config.
Issue Number: N/A


## What is the new behavior?
Absolute import in tests doesn't break them.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No, I hope so
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information