### PR TITLE
refactor(tests): add path to module mapper for jest tests

### DIFF
--- a/src/lib/application/application.factory.test.ts
+++ b/src/lib/application/application.factory.test.ts
@@ -21,6 +21,7 @@ describe('Application Factory', () => {
       '/project/.gitignore',
       '/project/.prettierrc',
       '/project/README.md',
+      '/project/jest.config.ts',
       '/project/nest-cli.json',
       '/project/package.json',
       '/project/tsconfig.build.json',
@@ -31,7 +32,7 @@ describe('Application Factory', () => {
       '/project/src/app.service.ts',
       '/project/src/main.ts',
       '/project/test/app.e2e-spec.ts',
-      '/project/test/jest-e2e.json',
+      '/project/test/jest-e2e.ts',
     ]);
   });
   it('should manage name to dasherize', async () => {
@@ -45,6 +46,7 @@ describe('Application Factory', () => {
       '/awesome-project/.gitignore',
       '/awesome-project/.prettierrc',
       '/awesome-project/README.md',
+      '/awesome-project/jest.config.ts',
       '/awesome-project/nest-cli.json',
       '/awesome-project/package.json',
       '/awesome-project/tsconfig.build.json',
@@ -55,7 +57,7 @@ describe('Application Factory', () => {
       '/awesome-project/src/app.service.ts',
       '/awesome-project/src/main.ts',
       '/awesome-project/test/app.e2e-spec.ts',
-      '/awesome-project/test/jest-e2e.json',
+      '/awesome-project/test/jest-e2e.ts',
     ]);
   });
   it('should manage javascript files', async () => {
@@ -96,6 +98,7 @@ describe('Application Factory', () => {
       '/scope-package/.gitignore',
       '/scope-package/.prettierrc',
       '/scope-package/README.md',
+      '/scope-package/jest.config.ts',
       '/scope-package/nest-cli.json',
       '/scope-package/package.json',
       '/scope-package/tsconfig.build.json',
@@ -106,7 +109,7 @@ describe('Application Factory', () => {
       '/scope-package/src/app.service.ts',
       '/scope-package/src/main.ts',
       '/scope-package/test/app.e2e-spec.ts',
-      '/scope-package/test/jest-e2e.json',
+      '/scope-package/test/jest-e2e.ts',
     ]);
   });
 });

--- a/src/lib/application/files/ts/jest.config.ts
+++ b/src/lib/application/files/ts/jest.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from '@jest/types';
+import { pathsToModuleNameMapper } from 'ts-jest/utils';
+import { compilerOptions } from './tsconfig.json';
+
+
+
+const moduleNameMapper = pathsToModuleNameMapper(compilerOptions.paths, {
+  prefix: '<rootDir>/',
+});
+
+const config: Config.InitialOptions = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.spec.ts$',
+  moduleNameMapper,
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.ts"
   },
   "dependencies": {
     "@nestjs/common": "^7.5.1",
@@ -49,22 +49,5 @@
     "ts-node": "^9.0.0",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^4.0.5"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/src/lib/application/files/ts/test/jest-e2e.json
+++ b/src/lib/application/files/ts/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
-}

--- a/src/lib/application/files/ts/test/jest-e2e.ts
+++ b/src/lib/application/files/ts/test/jest-e2e.ts
@@ -1,0 +1,19 @@
+import type { Config } from '@jest/types';
+import { pathsToModuleNameMapper } from 'ts-jest/utils';
+import { compilerOptions } from '../tsconfig.json';
+const moduleNameMapper = pathsToModuleNameMapper(compilerOptions.paths, {
+  prefix: '<rootDir>/../src/',
+});
+
+const config: Config.InitialOptions = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testRegex: '.e2e-spec.ts$',
+  moduleNameMapper,
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -10,6 +10,8 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "resolveJsonModule": true,
+    "paths": {}
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
With NestCLI we can now use the path option of tsconfig to add path resolution, and have it included in the generated build.
Unfortunately this does not work with jest.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When we add a new path to tsconfig, and use this new path in imports, jest can't resolve the modules.


## What is the new behavior?
Jest can now resolve modules imported using the path config from tsconfig file

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information