### PR TITLE
chore(): adding missing types to resource schematic

### DIFF
--- a/src/lib/class/schema.json
+++ b/src/lib/class/schema.json
@@ -14,10 +14,12 @@
       "x-prompt": "What name would you like to use for the class?"
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     },

--- a/src/lib/controller/schema.json
+++ b/src/lib/controller/schema.json
@@ -27,6 +27,7 @@
       "description": "Nest controller source root directory."
     },
     "skipImport": {
+      "type": "boolean",
       "description": "Flag to skip the module import.",
       "default": false
     },
@@ -35,10 +36,12 @@
       "description": "Allows specification of the declaring module."
     },
     "flat": {
+      "type": "boolean",
       "default": false,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/decorator/schema.json
+++ b/src/lib/decorator/schema.json
@@ -27,6 +27,7 @@
       "description": "Nest decorator source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     }

--- a/src/lib/filter/schema.json
+++ b/src/lib/filter/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest filter source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/gateway/schema.json
+++ b/src/lib/gateway/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest gateway source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/guard/schema.json
+++ b/src/lib/guard/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest guard source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/interceptor/schema.json
+++ b/src/lib/interceptor/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest interceptor source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/interface/schema.json
+++ b/src/lib/interface/schema.json
@@ -23,6 +23,7 @@
       "description": "Nest interface source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     }

--- a/src/lib/middleware/schema.json
+++ b/src/lib/middleware/schema.json
@@ -26,7 +26,7 @@
       "type": "string",
       "description": "Nest middleware source root directory."
     },
-    "flat":{
+    "flat": {
       "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."

--- a/src/lib/middleware/schema.json
+++ b/src/lib/middleware/schema.json
@@ -26,11 +26,13 @@
       "type": "string",
       "description": "Nest middleware source root directory."
     },
-    "flat": {
+    "flat":{
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/module/schema.json
+++ b/src/lib/module/schema.json
@@ -32,10 +32,12 @@
       "description": "Nest module source root directory."
     },
     "skipImport": {
+      "type": "boolean",
       "description": "Flag to skip the module import.",
       "default": false
     },
     "flat": {
+      "type": "boolean",
       "default": false,
       "description": "Flag to indicate if a directory is created."
     }

--- a/src/lib/pipe/schema.json
+++ b/src/lib/pipe/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest pipe source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/provider/schema.json
+++ b/src/lib/provider/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest provider source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     },

--- a/src/lib/resolver/schema.json
+++ b/src/lib/resolver/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest resolver source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": false,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }

--- a/src/lib/resource/schema.json
+++ b/src/lib/resource/schema.json
@@ -27,16 +27,18 @@
       "description": "Application language (ts/js)."
     },
     "flat": {
+      "type": "boolean",
       "default": false,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if specs file are generated."
     },
     "type": {
-      "description": "The transport layer.",
       "type": "string",
+      "description": "The transport layer.",
       "default": "rest",
       "enum": [
         "rest",
@@ -70,12 +72,13 @@
       }
     },
     "skipImport": {
+      "type": "boolean",
       "description": "Flag to skip the module import.",
       "default": false
     },
     "crud": {
-      "description": "When true, CRUD entry points are generated.",
       "type": "boolean",
+      "description": "When true, CRUD entry points are generated.",
       "default": true,
       "x-prompt": {
         "message": "Would you like to generate CRUD entry points?",

--- a/src/lib/service/schema.json
+++ b/src/lib/service/schema.json
@@ -27,10 +27,12 @@
       "description": "Nest service source root directory."
     },
     "flat": {
+      "type": "boolean",
       "default": false,
       "description": "Flag to indicate if a directory is created."
     },
     "spec": {
+      "type": "boolean",
       "default": true,
       "description": "Specifies if a spec file is generated."
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when using the angular console plugin from nrwl some parameters for the resource schematic show up as text fields, even though they are boolean values.

Issue Number: 561


## What is the new behavior?
Schematic fields show up correctly in angular-console plugin

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information