### PR TITLE
feat(application): enable strict mode for typescript

### DIFF
--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -6,6 +6,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
Strict mode is a good default for new projects, because it prevents
accidental omission of type safety information. It's much easier to
maintain strict mode compatibility from the start than it is to
retrofit a mature project to support strict mode.

That said, it's useful to default strictPropertyInitialization to
false for Nest projects, since the class-validator DTO pattern
described in the documentation is not compatible with strict property
initialization.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Projects created via `nest new` don't use TypeScript strict mode

Issue Number: N/A


## What is the new behavior?
Projects created via `nest new` use TypeScript strict mode

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information