### PR TITLE
`g resource` may use @Patch() in favor of @Put()

### DIFF
--- a/src/lib/resource/files/ts/__name__.controller.ts
+++ b/src/lib/resource/files/ts/__name__.controller.ts
@@ -26,7 +26,7 @@ export class <%= classify(name) %>Controller {
     return this.<%= lowercased(name) %>Service.findOne(+id);
   }
 
-  @Put(':id')
+  @Patch(':id')
   update(@Param('id') id: string, @Body() update<%= singular(classify(name)) %>Dto: Update<%= singular(classify(name)) %>Dto) {
     return this.<%= lowercased(name) %>Service.update(+id, update<%= singular(classify(name)) %>Dto);
   }

--- a/src/lib/resource/files/ts/__name__.controller.ts
+++ b/src/lib/resource/files/ts/__name__.controller.ts
@@ -1,4 +1,4 @@
-<% if (crud && type === 'rest') { %>import { Controller, Get, Post, Body, Put, Param, Delete } from '@nestjs/common';<%
+<% if (crud && type === 'rest') { %>import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';<%
 } else if (crud && type === 'microservice') { %>import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';<%
 } else { %>import { Controller } from '@nestjs/common';<%

--- a/src/lib/resource/resource.factory.test.ts
+++ b/src/lib/resource/resource.factory.test.ts
@@ -77,7 +77,7 @@ describe('Resource Factory', () => {
 
     it('should generate "UsersController" class', () => {
       expect(tree.readContent('/users/users.controller.ts'))
-        .toEqual(`import { Controller, Get, Post, Body, Put, Param, Delete } from '@nestjs/common';
+        .toEqual(`import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -101,7 +101,7 @@ export class UsersController {
     return this.usersService.findOne(+id);
   }
 
-  @Put(':id')
+  @Patch(':id')
   update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
     return this.usersService.update(+id, updateUserDto);
   }


### PR DESCRIPTION
Using `generate resource` creates an `update()` function annotated with `@Put()`. As of my understanding of REST API's `PUT` is meant to replace a full object or create one if it is not existing. But the created function clearly updates only specific values and integrates validation by use of `PartialType()`. Therefor, imo, `@Patch()` should be used instead which is meant to update only specific values of an existing object.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
