### PR TITLE
Module name mapper regex

### DIFF
--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -113,11 +113,9 @@ function updateJestConfig(
   if (!jestOptions.moduleNameMapper) {
     jestOptions.moduleNameMapper = {};
   }
-  const packageKeyRegex = '^' + packageKey + '$';
-  const deepPackagePathRegex = '^' + packageKey + '/(.*)' + '$';
+  const packageKeyRegex = '^' + packageKey + '(|/.*)$';
   const packageRoot = join('<rootDir>' as Path, distRoot);
-  jestOptions.moduleNameMapper[deepPackagePathRegex] = join(packageRoot, '$1');
-  jestOptions.moduleNameMapper[packageKeyRegex] = packageRoot;
+  jestOptions.moduleNameMapper[packageKeyRegex] = join(packageRoot, '$1');
 }
 
 function updateNpmScripts(

--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -113,10 +113,11 @@ function updateJestConfig(
   if (!jestOptions.moduleNameMapper) {
     jestOptions.moduleNameMapper = {};
   }
-  const deepPackagePath = packageKey + '/(.*)';
+  const packageKeyRegex = '^' + packageKey + '$';
+  const deepPackagePathRegex = '^' + packageKey + '/(.*)' + '$';
   const packageRoot = join('<rootDir>' as Path, distRoot);
-  jestOptions.moduleNameMapper[deepPackagePath] = join(packageRoot, '$1');
-  jestOptions.moduleNameMapper[packageKey] = packageRoot;
+  jestOptions.moduleNameMapper[deepPackagePathRegex] = join(packageRoot, '$1');
+  jestOptions.moduleNameMapper[packageKeyRegex] = packageRoot;
 }
 
 function updateNpmScripts(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #750 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The first commit fixes the problem addressed in the issue. The second commit makes the generated moduleNameMapper entries more clear by only adding one entry per library. 
The fixed original generated entry would be: 
```json
"moduleNameMapper": {
  "^@app/my-lib$": "<rootDir>/libs/my-lib/src",
  "^@app/my-lib/(.*)$": "<rootDir>/libs/my-lib/src/$1",
}
```
The new generated entry instead is:
```json
"moduleNameMapper": {
  "^@app/my-lib(|/.*)$": "<rootDir>/libs/my-lib/src/$1",
}
```
It matches either an empty string or everything starting with a slash to be inserted into $1.
The trailing slash should present no problem.
However, I would understand if you only want to merge the fix commit, in that case I can change the PR.