### PR TITLE
fix: remove classify for module import

### DIFF
--- a/src/lib/sub-app/files/ts/test/app.e2e-spec.ts
+++ b/src/lib/sub-app/files/ts/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { <%= classify(name)%>Module } from './../src/<%= classify(name)%>.module';
+import { <%= classify(name)%>Module } from './../src/<%= name %>.module';
 
 describe('<%= classify(name)%>Controller (e2e)', () => {
   let app: INestApplication;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This was capitalizing the module name when importing e2e tests when generating a new app in the monorepo scheme throwing invalid path error.

## What is the new behavior?
no errors with importing modules when creating a new sub-app.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information