### PR TITLE
Fix npm run lint command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'prettier/@typescript-eslint',
   ],
   root: true,
   env: {

--- a/src/lib/application/application.factory.ts
+++ b/src/lib/application/application.factory.ts
@@ -8,7 +8,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
-import { basename, parse, delimiter } from 'path';
+import { basename, parse } from 'path';
 import {
   DEFAULT_AUTHOR,
   DEFAULT_DESCRIPTION,

--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -1,9 +1,4 @@
-import {
-  join,
-  normalize,
-  Path,
-  strings,
-} from '@angular-devkit/core';
+import { join, normalize, Path, strings } from '@angular-devkit/core';
 import {
   apply,
   branchAndMerge,
@@ -17,7 +12,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
-import { parse } from "jsonc-parser"
+import { parse } from 'jsonc-parser';
 import {
   DEFAULT_LANGUAGE,
   DEFAULT_LIB_PATH,
@@ -178,7 +173,7 @@ function updateJsonFile<T>(
   if (source) {
     const sourceText = source.toString('utf-8');
     const json = parse(sourceText);
-    callback((json as {}) as T);
+    callback(json as unknown as T);
     host.overwrite(path, JSON.stringify(json, null, 2));
   }
   return host;

--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -1,9 +1,4 @@
-import {
-  join,
-  normalize,
-  Path,
-  strings,
-} from '@angular-devkit/core';
+import { join, normalize, Path, strings } from '@angular-devkit/core';
 import {
   apply,
   branchAndMerge,
@@ -18,11 +13,11 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
-import { parse } from "jsonc-parser"
 import * as fse from 'fs-extra';
+import { parse } from 'jsonc-parser';
 import {
-  DEFAULT_APP_NAME,
   DEFAULT_APPS_PATH,
+  DEFAULT_APP_NAME,
   DEFAULT_DIR_ENTRY_APP,
   DEFAULT_LANGUAGE,
   DEFAULT_LIB_PATH,
@@ -120,7 +115,7 @@ function updateJsonFile<T>(
   if (source) {
     const sourceText = source.toString('utf-8');
     const json = parse(sourceText);
-    callback((json as {}) as T);
+    callback(json as unknown as T);
     host.overwrite(path, JSON.stringify(json, null, 2));
   }
   return host;
@@ -188,9 +183,9 @@ function updateNpmScripts(
       defaultAppName,
       defaultTestDir,
     );
-    scripts[defaultTestScriptName] = (scripts[
-      defaultTestScriptName
-    ] as string).replace(defaultTestDir, newTestDir);
+    scripts[defaultTestScriptName] = (
+      scripts[defaultTestScriptName] as string
+    ).replace(defaultTestDir, newTestDir);
   }
   if (
     scripts[defaultFormatScriptName] &&
@@ -224,9 +219,8 @@ function updateJestOptions(
     jestOptions.roots.push(jestSourceRoot);
 
     const originalSourceRoot = `<rootDir>/src/`;
-    const originalSourceRootIndex = jestOptions.roots.indexOf(
-      originalSourceRoot,
-    );
+    const originalSourceRootIndex =
+      jestOptions.roots.indexOf(originalSourceRoot);
     if (originalSourceRootIndex >= 0) {
       (jestOptions.roots as string[]).splice(originalSourceRootIndex, 1);
     }

--- a/src/utils/metadata.manager.ts
+++ b/src/utils/metadata.manager.ts
@@ -32,7 +32,9 @@ export class MetadataManager {
     );
     const decoratorNodes: Node[] = this.getDecoratorMetadata(source, '@Module');
     const node: Node = decoratorNodes[0];
-    const matchingProperties: ObjectLiteralElement[] = (node as ObjectLiteralExpression).properties
+    const matchingProperties: ObjectLiteralElement[] = (
+      node as ObjectLiteralExpression
+    ).properties
       .filter((prop) => prop.kind === SyntaxKind.PropertyAssignment)
       .filter((prop: PropertyAssignment) => {
         const name = prop.name;
@@ -170,7 +172,7 @@ export class MetadataManager {
       node = arrLiteral.elements;
     }
     if (Array.isArray(node)) {
-      const nodeArray = (node as {}) as Node[];
+      const nodeArray = node as unknown as Node[];
       const symbolsArray = nodeArray.map((childNode) =>
         childNode.getText(source),
       );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [X] Code style update (formatting, local variables)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When you run `npm run lint` there is an error.
After the error got fixed there were some lint errors so they are fixed as well.

```
Error
 npm run lint

> @nestjs/schematics@8.0.7 lint
> eslint '{src,test}/**/*.ts' --fix


Oops! Something went wrong! :(

ESLint: 8.10.0

Error: Cannot read config file: /home/zlatin/code/experiments/schematics/node_modules/eslint-config-prettier/@typescript-eslint.js
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
Referenced from: /home/zlatin/code/experiments/schematics/.eslintrc.js
    at Object.<anonymous> (/home/zlatin/code/experiments/schematics/node_modules/eslint-config-prettier/@typescript-eslint.js:1:69)
    at Module._compile (/home/zlatin/code/experiments/schematics/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at Object.module.exports [as default] (/home/zlatin/code/experiments/schematics/node_modules/import-fresh/index.js:31:59)
    at loadJSConfigFile (/home/zlatin/code/experiments/schematics/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2559:47)
    at loadConfigFile (/home/zlatin/code/experiments/schematics/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2643:20)
    at ConfigArrayFactory._loadConfigData (/home/zlatin/code/experiments/schematics/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2947:42)
```

## What is the new behavior?

npm run lint works and the lint errors are fixed.
There is a warning since the project uses a newer TypeScript patch version, but I assume this will be handled by the prettier/eslint team.

````
npm run lint

> @nestjs/schematics@8.0.7 lint
> eslint '{src,test}/**/*.ts' --fix

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.6.0

YOUR TYPESCRIPT VERSION: 4.6.2

Please only submit bug reports when using the officially supported version.

=============`
```

## Does this PR introduce a breaking change?
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
