### PR TITLE
feat: add `$schema` entry on generated `nest-cli.json` files

### DIFF
--- a/src/lib/application/files/js/nest-cli.json
+++ b/src/lib/application/files/js/nest-cli.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/nest-cli",
   "language": "js",
   "collection": "@nestjs/schematics",
   "sourceRoot": "src"

--- a/src/lib/application/files/ts/nest-cli.json
+++ b/src/lib/application/files/ts/nest-cli.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
   "sourceRoot": "src"
 }

--- a/src/lib/configuration/configuration.factory.test.ts
+++ b/src/lib/configuration/configuration.factory.test.ts
@@ -20,6 +20,7 @@ describe('Configuration Factory', () => {
       files.find(filename => filename === '/project/nest-cli.json'),
     ).not.toBeUndefined();
     expect(JSON.parse(tree.readContent('/project/nest-cli.json'))).toEqual({
+      $schema: 'https://json.schemastore.org/nest-cli',
       collection: '@nestjs/schematics',
       sourceRoot: 'src',
     });
@@ -35,6 +36,7 @@ describe('Configuration Factory', () => {
       files.find(filename => filename === '/project/nest-cli.json'),
     ).not.toBeUndefined();
     expect(JSON.parse(tree.readContent('/project/nest-cli.json'))).toEqual({
+      $schema: 'https://json.schemastore.org/nest-cli',
       language: 'js',
       collection: '@nestjs/schematics',
       sourceRoot: 'src',
@@ -51,6 +53,7 @@ describe('Configuration Factory', () => {
       files.find(filename => filename === '/project/nest-cli.json'),
     ).not.toBeUndefined();
     expect(JSON.parse(tree.readContent('/project/nest-cli.json'))).toEqual({
+      $schema: 'https://json.schemastore.org/nest-cli',
       collection: 'foo',
       sourceRoot: 'src',
     });

--- a/src/lib/configuration/files/js/nest-cli.json
+++ b/src/lib/configuration/files/js/nest-cli.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/nest-cli",
   "language": "<%= language %>",
   "collection": "<%= collection %>",
   "sourceRoot": "src"

--- a/src/lib/configuration/files/ts/nest-cli.json
+++ b/src/lib/configuration/files/ts/nest-cli.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "<%= collection %>",
   "sourceRoot": "src"
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the new behavior?

The schema URL was taken from here: https://www.schemastore.org/json and was reviewed here: https://github.com/SchemaStore/schemastore/pull/1947

This is just to help devs on building the `nest-cli.json` file in their IDE/code editor. We'll get no errors if some field is not allowed but we'll get autocompletion for the ones that are allowed

![image](https://user-images.githubusercontent.com/13461315/160671891-69401520-4622-4387-8dad-3aad08b7ae8b.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No