### PR TITLE
fix(utils): when imports list has no indentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Stack Overflow is a much better place to ask questions since:
 
 To save your and our time, we will systematically close all issues that are requests for general support and redirect people to Stack Overflow.
 
-If you would like to chat about the question in real-time, you can reach out via [our gitter channel][gitter].
+If you would like to chat about the question in real-time, you can reach out via [our discord channel][discord].
 
 ## <a name="issue"></a> Found a Bug?
 If you find a bug in the source code, you can help us by
@@ -243,7 +243,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html
 [dev-doc]: https://github.com/nestjs/nest/blob/master/docs/DEVELOPER.md
 [github]: https://github.com/nestjs/nest
-[gitter]: https://gitter.im/nestjs/nest
+[discord]: https://discord.gg/nestjs
 [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html
 [js-style-guide]: https://google.github.io/styleguide/jsguide.html
 [jsfiddle]: http://jsfiddle.net

--- a/src/utils/metadata.manager.ts
+++ b/src/utils/metadata.manager.ts
@@ -189,11 +189,12 @@ export class MetadataManager {
       toInsert = staticOptions ? this.addBlankLines(symbol) : `${symbol}`;
     } else {
       const text = (node as Node).getFullText(source);
-      if (text.match(/^\r?\n/)) {
-        toInsert = `,${text.match(/^\r?\n(\r?)\s+/)[0]}${symbol}`;
-      } else {
-        toInsert = `, ${symbol}`;
-      }
+      const itemSeparator = ( 
+        text.match(/^\r?\n(\r?)\s+/) ||
+        text.match(/^\r?\n/) ||
+        ' '
+      )[0];
+      toInsert = `,${itemSeparator}${symbol}`;
     }
     return this.content.split('').reduce((content, char, index) => {
       if (index === position) {

--- a/test/utils/metadata.manager.test.ts
+++ b/test/utils/metadata.manager.test.ts
@@ -60,6 +60,51 @@ describe('Metadata Manager', () => {
       'export class FooModule {}\n'
     );
   });
+  it('should insert the symbol to the metadata reusing the line separator', () => {
+    const lineSeparator = '\r\n'
+
+    const manager = new MetadataManager(
+      'import { Module } from \'@nestjs/common\';\n' +
+      '\n' +
+      '@Module({\n' +
+      `  imports: [${lineSeparator}` +
+      'BarModule]\n' +
+      '})\n' +
+      'export class FooModule {}\n'
+    );
+    const metadata = 'imports';
+    const symbol = 'FooModule';
+    expect(manager.insert(metadata, symbol)).toEqual(
+      'import { Module } from \'@nestjs/common\';\n' +
+      '\n' +
+      '@Module({\n' +
+      `  imports: [${lineSeparator}` +
+      `BarModule,${lineSeparator}`+
+      'FooModule]\n' +
+      '})\n' +
+      'export class FooModule {}\n'
+    );
+  });
+  it("should insert the symbol to the metadata separated by a blank space when there's no line separator", () => {
+    const manager = new MetadataManager(
+      'import { Module } from \'@nestjs/common\';\n' +
+      '\n' +
+      '@Module({\n' +
+      '  imports: [BarModule]\n' +
+      '})\n' +
+      'export class FooModule {}\n'
+    );
+    const metadata = 'imports';
+    const symbol = 'FooModule';
+    expect(manager.insert(metadata, symbol)).toEqual(
+      'import { Module } from \'@nestjs/common\';\n' +
+      '\n' +
+      '@Module({\n' +
+      '  imports: [BarModule, FooModule]\n' +
+      '})\n' +
+      'export class FooModule {}\n'
+    );
+  });
   it('should insert the symbol to right metadata', () => {
     const metadata = 'imports';
     const symbol = 'FooModule';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?


Issue Number: closes https://github.com/nestjs/nest-cli/issues/1639


## What is the new behavior?

now we can have a module declaration like the following:

```ts
@Module({
  imports: [
FooModule, // <<
  ],
})
export class AppModule {}
```

and `nest g module bar` will turn that into:

```ts
import { BarModule } from './bar/bar.module';

@Module({
  imports: [
FooModule,
BarModule, // <<
  ],
})
export class AppModule {}
```

<details>
<summary>Other examples</summary>

```ts
// FROM this:

@Module({
  imports: [
FooModule
  ],
})
export class AppModule {}

// TO this:

@Module({
  imports: [
FooModule,
BarModule
  ],
})
export class AppModule {}
```

```ts
// FROM this:

@Module({
  imports: [
 FooModule, // <<
  ],
})
export class AppModule {}

// TO this:

@Module({
  imports: [
 FooModule,
 BarModule, // <<
  ],
})
export class AppModule {}
```

```ts
// FROM this:

@Module({
  imports: [FooModule, // <<
  ],
})
export class AppModule {}

// TO this:

@Module({
  imports: [FooModule, BarModule, // <<
  ],
})
export class AppModule {}
```


</details>

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
