### PR TITLE
feat: run all app e2e tests when configuring new sub apps

### DIFF
--- a/src/lib/sub-app/sub-app.factory.test.ts
+++ b/src/lib/sub-app/sub-app.factory.test.ts
@@ -20,6 +20,7 @@ describe('SubApp Factory', () => {
     const files: string[] = tree.files;
     expect(files.sort()).toEqual([
       '/nest-cli.json',
+      '/jest-e2e.json',
       '/apps/nestjs-schematics/tsconfig.app.json',
       '/apps/project/tsconfig.app.json',
       '/apps/project/src/main.ts',
@@ -30,6 +31,13 @@ describe('SubApp Factory', () => {
       '/apps/project/test/app.e2e-spec.ts',
       '/apps/project/test/jest-e2e.json',
     ].sort());
+
+    expect(JSON.parse(tree.readContent('/jest-e2e.json'))).toMatchObject({
+      projects: [
+        'apps/nestjs-schematics/test/jest-e2e.json',
+        'apps/project/test/jest-e2e.json',
+      ]
+    });
   });
   it('should manage name to normalize', async () => {
     const options: SubAppOptions = {
@@ -41,6 +49,7 @@ describe('SubApp Factory', () => {
     const files: string[] = tree.files;
     expect(files.sort()).toEqual([
       '/nest-cli.json',
+      '/jest-e2e.json',
       '/apps/nestjs-schematics/tsconfig.app.json',
       '/apps/awesome-project/tsconfig.app.json',
       '/apps/awesome-project/src/main.ts',
@@ -51,6 +60,13 @@ describe('SubApp Factory', () => {
       '/apps/awesome-project/test/app.e2e-spec.ts',
       '/apps/awesome-project/test/jest-e2e.json',
     ].sort());
+
+    expect(JSON.parse(tree.readContent('/jest-e2e.json'))).toMatchObject({
+      projects: [
+        'apps/nestjs-schematics/test/jest-e2e.json',
+        'apps/awesome-project/test/jest-e2e.json',
+      ]
+    });
   });
   it("should keep underscores in sub-app's path and file name", async () => {
     const options: SubAppOptions = {
@@ -62,6 +78,7 @@ describe('SubApp Factory', () => {
     const files: string[] = tree.files;
     expect(files.sort()).toEqual([
       '/nest-cli.json',
+      '/jest-e2e.json',
       '/apps/nestjs-schematics/tsconfig.app.json',
       '/apps/_project/tsconfig.app.json',
       '/apps/_project/src/main.ts',
@@ -72,6 +89,13 @@ describe('SubApp Factory', () => {
       '/apps/_project/test/app.e2e-spec.ts',
       '/apps/_project/test/jest-e2e.json',
     ].sort());
+
+    expect(JSON.parse(tree.readContent('/jest-e2e.json'))).toMatchObject({
+      projects: [
+        'apps/nestjs-schematics/test/jest-e2e.json',
+        'apps/_project/test/jest-e2e.json',
+      ]
+    });
   });
   it('should manage javascript files', async () => {
     const options: SubAppOptions = {
@@ -84,6 +108,7 @@ describe('SubApp Factory', () => {
     const files: string[] = tree.files;
     expect(files.sort()).toEqual([
       '/nest-cli.json',
+      '/jest-e2e.json',
       '/apps/nestjs-schematics/.babelrc',
       '/apps/nestjs-schematics/index.js',
       '/apps/nestjs-schematics/jsconfig.json',
@@ -98,6 +123,13 @@ describe('SubApp Factory', () => {
       '/apps/project/test/app.e2e-spec.js',
       '/apps/project/test/jest-e2e.json',
     ].sort());
+
+    expect(JSON.parse(tree.readContent('/jest-e2e.json'))).toMatchObject({
+      projects: [
+        'apps/nestjs-schematics/test/jest-e2e.json',
+        'apps/project/test/jest-e2e.json',
+      ]
+    });
   });
   it('should generate spec files with custom suffix', async () => {
     const options: SubAppOptions = {
@@ -110,6 +142,7 @@ describe('SubApp Factory', () => {
     const files: string[] = tree.files;
     expect(files.sort()).toEqual([
       '/nest-cli.json',
+      '/jest-e2e.json',
       '/apps/nestjs-schematics/tsconfig.app.json',
       '/apps/project/tsconfig.app.json',
       '/apps/project/src/main.ts',
@@ -120,5 +153,12 @@ describe('SubApp Factory', () => {
       '/apps/project/test/jest-e2e.json',
       '/apps/project/test/app.e2e-test.ts',
     ].sort());
+
+    expect(JSON.parse(tree.readContent('/jest-e2e.json'))).toMatchObject({
+      projects: [
+        'apps/nestjs-schematics/test/jest-e2e.json',
+        'apps/project/test/jest-e2e.json',
+      ]
+    });
   });
 });


### PR DESCRIPTION
When a new SubApp is added to a project the project is now configured to run all E2E tests by default. Currently it only runs the main app E2E tests.

Closes #1167.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1167


## What is the new behavior?

It will now create a new `jest-e2e.json` file in the `./apps` root directory containing references to each sub apps E2E test configs.

```json
{
  "projects": [
    "apps/app-one/test/jest-e2e.json",
    "apps/app-two/test/jest-e2e.json",
    "apps/app-three/test/jest-e2e.json",
    "apps/app-four/test/jest-e2e.json"
  ]
}
```

And updating the the `test:e2e` to now run `jest --config apps/jest-e2e.json`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@kamilmysliwiec this differs from the open issue slightly because as I was testing on my own monorepo with 3 sub apps, the `package.json` `test:e2e` script would come out rather long and not scalable:

```json
"test:e2e": "jest --projects ./apps/my-app/test/jest-e2e.json ./apps/my-other-app/test/jest-e2e.json ./apps/my-different-app/test/jest-e2e.json"
```

So instead I opted for a dedicated `jest-e2e.json` that references all the different project configs.

Appreciate any and all feedback!