### PR TITLE
fix: use correct path in `start:prod` script with sub apps

### DIFF
--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -170,8 +170,13 @@ function updateNpmScripts(
     return;
   }
   const defaultFormatScriptName = 'format';
+  const defaultStartScriptName = 'start:prod';
   const defaultTestScriptName = 'test:e2e';
-  if (!scripts[defaultTestScriptName] && !scripts[defaultFormatScriptName]) {
+  if (
+    !scripts[defaultTestScriptName] &&
+    !scripts[defaultFormatScriptName] &&
+    !scripts[defaultStartScriptName]
+  ) {
     return;
   }
   if (
@@ -197,6 +202,16 @@ function updateNpmScripts(
     scripts[
       defaultFormatScriptName
     ] = `prettier --write "${defaultSourceRoot}/**/*.ts" "${DEFAULT_LIB_PATH}/**/*.ts"`;
+  }
+  if (
+    scripts[defaultStartScriptName] &&
+    scripts[defaultStartScriptName].indexOf('dist/main') >= 0
+  ) {
+    const defaultSourceRoot =
+      options.rootDir !== undefined ? options.rootDir : DEFAULT_APPS_PATH;
+    scripts[
+      defaultStartScriptName
+      ] = `node dist/${defaultSourceRoot}/${defaultAppName}/main`;
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If using sub apps inside a monorepo running `npm run build` or `nest build <app_name>` puts the build files inside the path `dist/apps/<app_name>`.

However, the `npm run start:prod` script still points to `dist/main` - the old location before the project became a monorepo.

## What is the new behavior?

`npm run start:prod` now points to `dist/apps/<app_name>/main`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A