### PR TITLE
feat: use auto-delete output dir feature from nestjs cli

### DIFF
--- a/src/lib/application/files/ts/nest-cli.json
+++ b/src/lib/application/files/ts/nest-cli.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
 }

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -6,7 +6,6 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
@@ -25,7 +24,6 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "reflect-metadata": "^0.1.13",
-    "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As mentioned here: https://github.com/nestjs/typescript-starter/pull/242 nestjs apps created by `nest new` have the dev. dependency `rimraf` due to the npm-script `prebuild`

But people might not want that npm-script neither that dependency on their projects

## What is the new behavior?

As NestJS's CLI have the auto-delete output dir feature (which uses `rimraf` under the hood), I don't see any advantages on having that npm-script on user-land.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

