### PR TITLE
fix: add trailing commas to resource schematic

### DIFF
--- a/src/lib/resource/files/ts/__name__.module.ts
+++ b/src/lib/resource/files/ts/__name__.module.ts
@@ -4,6 +4,6 @@ import { <%= classify(name) %>Service } from './<%= name %>.service';
 
 @Module({
   <% if (type === 'rest' || type === 'microservice') { %>controllers: [<%= classify(name) %>Controller],
-  providers: [<%= classify(name) %>Service]<% } else if (type === 'graphql-code-first' || type === 'graphql-schema-first') { %>providers: [<%= classify(name) %>Resolver, <%= classify(name) %>Service]<% } else { %>providers: [<%= classify(name) %>Gateway, <%= classify(name) %>Service]<% } %>
+  providers: [<%= classify(name) %>Service],<% } else if (type === 'graphql-code-first' || type === 'graphql-schema-first') { %>providers: [<%= classify(name) %>Resolver, <%= classify(name) %>Service],<% } else { %>providers: [<%= classify(name) %>Gateway, <%= classify(name) %>Service],<% } %>
 })
 export class <%= classify(name) %>Module {}

--- a/src/lib/resource/resource.factory.test.ts
+++ b/src/lib/resource/resource.factory.test.ts
@@ -179,7 +179,7 @@ import { UsersController } from './users.controller';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService]
+  providers: [UsersService],
 })
 export class UsersModule {}
 `);
@@ -298,7 +298,7 @@ import { UsersController } from './users.controller';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService]
+  providers: [UsersService],
 })
 export class UsersModule {}
 `);
@@ -470,7 +470,7 @@ import { UsersController } from './users.controller';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService]
+  providers: [UsersService],
 })
 export class UsersModule {}
 `);
@@ -592,7 +592,7 @@ import { UsersController } from './users.controller';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService]
+  providers: [UsersService],
 })
 export class UsersModule {}
 `);
@@ -762,7 +762,7 @@ import { UsersService } from './users.service';
 import { UsersGateway } from './users.gateway';
 
 @Module({
-  providers: [UsersGateway, UsersService]
+  providers: [UsersGateway, UsersService],
 })
 export class UsersModule {}
 `);
@@ -881,7 +881,7 @@ import { UsersService } from './users.service';
 import { UsersGateway } from './users.gateway';
 
 @Module({
-  providers: [UsersGateway, UsersService]
+  providers: [UsersGateway, UsersService],
 })
 export class UsersModule {}
 `);
@@ -1052,7 +1052,7 @@ import { UsersService } from './users.service';
 import { UsersResolver } from './users.resolver';
 
 @Module({
-  providers: [UsersResolver, UsersService]
+  providers: [UsersResolver, UsersService],
 })
 export class UsersModule {}
 `);
@@ -1294,7 +1294,7 @@ import { UsersService } from './users.service';
 import { UsersResolver } from './users.resolver';
 
 @Module({
-  providers: [UsersResolver, UsersService]
+  providers: [UsersResolver, UsersService],
 })
 export class UsersModule {}
 `);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Fixes #1458; see issue for description


## What is the new behavior?

Resource module files now include a trailing comma for the object argument passed into `@Module()`


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

None