### PR TITLE
fix: when generating app with no 'test'/'src' folder to move

### DIFF
--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -279,9 +279,8 @@ function moveDirectoryTo(
   tree.getDir(srcDir).visit((filePath: Path, file: Readonly<FileEntry>) => {
     const newFilePath = join(destination as Path, filePath);
     tree.create(newFilePath, file.content);
-    tree.delete(filePath);
+    tree.delete(srcDir);
   });
-  tree.delete(srcDir);
 }
 
 function addAppsToCliOptions(

--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -276,11 +276,15 @@ function moveDirectoryTo(
   destination: string,
   tree: Tree,
 ): void {
+  let srcDirExists = false;
   tree.getDir(srcDir).visit((filePath: Path, file: Readonly<FileEntry>) => {
+    srcDirExists = true;
     const newFilePath = join(destination as Path, filePath);
     tree.create(newFilePath, file.content);
-    tree.delete(srcDir);
   });
+  if (srcDirExists) {
+    tree.delete(srcDir);
+  }
 }
 
 function addAppsToCliOptions(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #1492

given this project:

![image](https://github.com/nestjs/schematics/assets/13461315/e6d9a15f-3e1a-4e46-a87f-e59e88ca6f80)

(note that we have the 'test' folder just to see what's the happy path)

running `npx nest g app qux` will perform the following operations:

![image](https://github.com/nestjs/schematics/assets/13461315/a7a54b99-5cd7-48d5-96b2-01622cf4927a)

we are deleting every file within the directories that will be moved ('src' and 'test')

## What is the new behavior?

now that same command will do this instead:

![image](https://github.com/nestjs/schematics/assets/13461315/95261ad8-50fc-4765-9654-8e8382725a6f)

- only 2 _delete_ operations, one for each folder being deleted
- ignore if the folder does not exists

---

when there is no 'test' folder in the project, we'd see:

![image](https://github.com/nestjs/schematics/assets/13461315/1381f3db-6950-4cfb-89fd-b2303dde9974)

![image](https://github.com/nestjs/schematics/assets/13461315/58f4835d-0e91-4dc8-b281-9babb8d12402)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
