### PR TITLE
feat: remove `@nestjs/schematics` dev dependency from generated nestjs app

### DIFF
--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
-    "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@nestjs/schematics` is installed as a dev dep but it is also a hard dependency of `@nestjs/cli`. Thus I didn't see any reasons for that dependency to live on the app side :thinking: That seems redundant to me

![image](https://github.com/nestjs/schematics/assets/13461315/6549a8cc-bbcd-4716-ae57-fa619c6a31ca)


## What is the new behavior?

we have less dependencies in our new project, which I believe is slightly more friendly to newcomers while also enforcing a parity between the versions of `@nestjs/cli` and `@nestjs/schematics`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


