### PR TITLE
feat: use default library prefix

### DIFF
--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -53,6 +53,15 @@ function getDefaultLibraryPrefix(defaultLibraryPrefix = '@app') {
       return nestCliJson['defaultLibraryPrefix'];
     }
   } catch (e) {
+    try {
+      const nestJson = JSON.parse(
+        readFileSync('./nest.json', 'utf-8'),
+      );
+      if (nestJson.hasOwnProperty('defaultLibraryPrefix')) {
+        return nestJson['defaultLibraryPrefix'];
+      }
+    } catch (e) {
+    }
   }
   
   return defaultLibraryPrefix;

--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -13,6 +13,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { parse } from 'jsonc-parser';
+import { readFileSync } from 'fs';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DEFAULT_LANGUAGE,
@@ -43,6 +44,20 @@ export function main(options: LibraryOptions): Rule {
   ]);
 }
 
+function getDefaultLibraryPrefix(defaultLibraryPrefix = '@app') {
+  try {
+    const nestCliJson = JSON.parse(
+      readFileSync('./nest-cli.json', 'utf-8'),
+    );
+    if (nestCliJson.hasOwnProperty('defaultLibraryPrefix')) {
+      return nestCliJson['defaultLibraryPrefix'];
+    }
+  } catch (e) {
+  }
+  
+  return defaultLibraryPrefix;
+}
+
 function transform(options: LibraryOptions): LibraryOptions {
   const target: LibraryOptions = Object.assign({}, options);
   const defaultSourceRoot =
@@ -58,7 +73,7 @@ function transform(options: LibraryOptions): LibraryOptions {
       ? join(normalize(defaultSourceRoot), target.path)
       : normalize(defaultSourceRoot);
 
-  target.prefix = target.prefix || '@app';
+  target.prefix = target.prefix || getDefaultLibraryPrefix();
   return target;
 }
 

--- a/src/lib/library/schema.json
+++ b/src/lib/library/schema.json
@@ -16,7 +16,7 @@
     "prefix": {
       "type": "string",
       "description": "The prefix of the library.",
-      "x-prompt": "What prefix would you like to use for the library (default: @app)?"
+      "x-prompt": "What prefix would you like to use for the library (default: defaultLibraryPrefix or @app)?"
     },
     "language": {
       "type": "string",

--- a/src/lib/library/schema.json
+++ b/src/lib/library/schema.json
@@ -16,7 +16,7 @@
     "prefix": {
       "type": "string",
       "description": "The prefix of the library.",
-      "x-prompt": "What prefix would you like to use for the library (default: @app or "defaultLibraryPrefix" setting value)?"
+      "x-prompt": "What prefix would you like to use for the library (default: @app or 'defaultLibraryPrefix' setting value)?"
     },
     "language": {
       "type": "string",

--- a/src/lib/library/schema.json
+++ b/src/lib/library/schema.json
@@ -16,7 +16,7 @@
     "prefix": {
       "type": "string",
       "description": "The prefix of the library.",
-      "x-prompt": "What prefix would you like to use for the library (default: defaultLibraryPrefix or @app)?"
+      "x-prompt": "What prefix would you like to use for the library (default: @app or "defaultLibraryPrefix" setting value)?"
     },
     "language": {
       "type": "string",

--- a/src/lib/readers/file-system.reader.ts
+++ b/src/lib/readers/file-system.reader.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Reader } from './reader';
+
+export class FileSystemReader implements Reader {
+  constructor(private readonly directory: string) {}
+  
+  public list(): Promise<string[]> {
+    return fs.promises.readdir(this.directory);
+  }
+  
+  public read(name: string): Promise<string> {
+    return fs.promises.readFile(path.join(this.directory, name), 'utf8');
+  }
+  
+  public readSync(name: string): string {
+    return fs.readFileSync(path.join(this.directory, name), 'utf8');
+  }
+  
+  public async readAnyOf(filenames: string[]): Promise<string | undefined> {
+    try {
+      for (const file of filenames) {
+        return await this.read(file);
+      }
+    } catch (err) {
+      return filenames.length > 0
+        ? await this.readAnyOf(filenames.slice(1, filenames.length))
+        : undefined;
+    }
+  }
+  
+  public readSyncAnyOf(filenames: string[]): string | undefined {
+    try {
+      for (const file of filenames) {
+        return this.readSync(file);
+      }
+    } catch (err) {
+      return filenames.length > 0
+        ? this.readSyncAnyOf(filenames.slice(1, filenames.length))
+        : undefined;
+    }
+  }
+}

--- a/src/lib/readers/index.ts
+++ b/src/lib/readers/index.ts
@@ -1,0 +1,2 @@
+export * from './reader';
+export * from './file-system.reader';

--- a/src/lib/readers/reader.ts
+++ b/src/lib/readers/reader.ts
@@ -1,0 +1,7 @@
+export interface Reader {
+  list(): string[] | Promise<string[]>;
+  read(name: string): string | Promise<string>;
+  readSync(name: string): string;
+  readAnyOf(filenames: string[]): string | Promise<string | undefined>;
+  readSyncAnyOf(filenames: string[]): string | undefined;
+}

--- a/test/lib/readers/file-system.reader.spec.ts
+++ b/test/lib/readers/file-system.reader.spec.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import { FileSystemReader, Reader } from '../../../src/lib/readers';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn().mockReturnValue('content'),
+  promises: {
+    readdir: jest.fn().mockResolvedValue([]),
+    readFile: jest.fn().mockResolvedValue('content'),
+  },
+}));
+
+const dir: string = process.cwd();
+const reader: Reader = new FileSystemReader(dir);
+
+describe('File System Reader', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+  it('should use fs.promises.readdir when list', async () => {
+    await reader.list();
+    expect(fs.promises.readdir).toHaveBeenCalled();
+  });
+  it('should use fs.promises.readFile when read', async () => {
+    await reader.read('filename');
+    expect(fs.promises.readFile).toHaveBeenCalled();
+  });
+  
+  describe('readAnyOf tests', () => {
+    it('should call readFile when running readAnyOf fn', async () => {
+      const filenames: string[] = ['file1', 'file2', 'file3'];
+      await reader.readAnyOf(filenames);
+      
+      expect(fs.promises.readFile).toHaveBeenCalled();
+    });
+    
+    it('should return undefined when no file is passed', async () => {
+      const content = await reader.readAnyOf([]);
+      expect(content).toEqual(undefined);
+    });
+  });
+  
+  describe('readSyncAnyOf tests', () => {
+    it('should call readFileSync when running readSyncAnyOf fn', async () => {
+      const filenames: string[] = ['file1', 'file2', 'file3'];
+      reader.readSyncAnyOf(filenames);
+      
+      expect(fs.readFileSync).toHaveBeenCalled();
+    });
+    
+    it('should return undefined when no file is passed', async () => {
+      const content = reader.readSyncAnyOf([]);
+      expect(content).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1562 


## What is the new behavior?

if defaultLibraryPrefix key exists, use this prefix first.

```
{
  ...
  "monorepo": true,
  "defaultLibraryPrefix": "@my-company"
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I wanna change x-prompt message dynamically, but there is no way to make it dynamically for now.
so I have changed the message, but I think the message is not that good.
let me advise.
It is my first time to contribute to nestjs/schematics, You can give me any feedback, it's all welcome.
