### PR TITLE
refactor: narrow the type of `app` on e2e template file

### DIFF
--- a/src/lib/application/files/ts/test/app.e2e-__specFileSuffix__.ts
+++ b/src/lib/application/files/ts/test/app.e2e-__specFileSuffix__.ts
@@ -1,10 +1,11 @@
+import type { Server } from 'net';
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication;
+  let app: INestApplication<Server>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/src/lib/sub-app/files/ts/test/app.e2e-__specFileSuffix__.ts
+++ b/src/lib/sub-app/files/ts/test/app.e2e-__specFileSuffix__.ts
@@ -1,10 +1,11 @@
+import type { Server } from 'net';
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { <%= classify(name)%>Module } from './../src/<%= name %>.module';
 
 describe('<%= classify(name)%>Controller (e2e)', () => {
-  let app: INestApplication;
+  let app: INestApplication<Server>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: related with https://github.com/nestjs/nest/issues/13191

if we enable the ESLint rule `@typescript-eslint/no-unsafe-argument`, we'll see the following error:

![image](https://github.com/nestjs/schematics/assets/13461315/3f3a6b86-b415-4a77-81d2-612d720fa566)

> Unsafe argument of type `any` assigned to a parameter of type `App`

## What is the new behavior?

allow us to enable the ESLint TS rule `@typescript-eslint/no-unsafe-argument` because the return type of `app.getHttpServer()` is not `any` now

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

tbh I'm not sure if this is something that the dev should handle instead of having it as default because the generated code doesn't have that rule enabled.
