### PR TITLE
feat: enable `forceConsistentCasingInFileNames` for 'application' template

### DIFF
--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
+    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "strictNullChecks": <%= strict %>,
     "noImplicitAny": <%= strict %>,


### PR DESCRIPTION
as per https://github.com/nestjs/typescript-starter/pull/311/

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
