### PR TITLE
Revert "feat: enable `forceConsistentCasingInFileNames` for 'application' template"

### DIFF
--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -11,7 +11,6 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
-    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "strictNullChecks": <%= strict %>,
     "noImplicitAny": <%= strict %>,


### PR DESCRIPTION
Reverts nestjs/schematics#1899