### PR TITLE
feat: sort library and sub-app names to reduce git merge conflicts

### DIFF
--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -13,7 +13,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { parse } from 'jsonc-parser';
-import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
+import { inPlaceSortByKeys, normalizeToKebabOrSnakeCase } from '../../utils';
 import {
   DEFAULT_LANGUAGE,
   DEFAULT_LIB_PATH,
@@ -133,6 +133,8 @@ function updateJestConfig(
   const packageKeyRegex = '^' + packageKey + '(|/.*)$';
   const packageRoot = join('<rootDir>' as Path, distRoot);
   jestOptions.moduleNameMapper[packageKeyRegex] = join(packageRoot, '$1');
+
+  inPlaceSortByKeys(jestOptions.moduleNameMapper);
 }
 
 function updateNpmScripts(
@@ -181,6 +183,8 @@ function updateJestEndToEnd(options: LibraryOptions) {
         const packageRoot = '<rootDir>/../' + distRoot;
         jestOptions.moduleNameMapper[deepPackagePath] = packageRoot + '/$1';
         jestOptions.moduleNameMapper[packageKey] = packageRoot;
+
+        inPlaceSortByKeys(jestOptions.moduleNameMapper);
       },
     );
   };
@@ -238,6 +242,8 @@ function updateTsConfig(
           tsconfig.compilerOptions.paths[deepPackagePath] = [];
         }
         tsconfig.compilerOptions.paths[deepPackagePath].push(distRoot + '/*');
+
+        inPlaceSortByKeys(tsconfig.compilerOptions.paths);
       },
     );
   };
@@ -284,6 +290,8 @@ function addLibraryToCliOptions(
           );
         }
         optionsFile.projects[projectName] = project;
+
+        inPlaceSortByKeys(optionsFile.projects);
       },
     );
   };

--- a/src/lib/sub-app/sub-app.factory.test.ts
+++ b/src/lib/sub-app/sub-app.factory.test.ts
@@ -1,8 +1,10 @@
+import { EmptyTree, Tree } from '@angular-devkit/schematics';
 import {
   SchematicTestRunner,
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
+import { LibraryOptions } from '../library/library.schema';
 import { SubAppOptions } from './sub-app.schema';
 
 describe('SubApp Factory', () => {
@@ -125,5 +127,32 @@ describe('SubApp Factory', () => {
         '/apps/project/test/app.e2e-test.ts',
       ].sort(),
     );
+  });
+
+  it('should sort sub-app names in nest-cli.json', async () => {
+    const options: SubAppOptions[] = [
+      {
+        name: 'c',
+        language: 'ts',
+      },
+      {
+        name: 'a',
+        language: 'ts',
+      },
+      {
+        name: 'b',
+        language: 'ts',
+      }
+    ];
+
+    let tree: Tree = new EmptyTree();
+    tree.create('/nest-cli.json', `{"monorepo": true, "projects": {}}`);
+
+    for (const o of options) {
+      tree = await runner.runSchematic('sub-app', o, tree);
+    }
+
+    const config = tree.readJson('/nest-cli.json');
+    expect(Object.keys(config['projects'])).toEqual(['a', 'b', 'c']); // Sorted
   });
 });

--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -16,7 +16,7 @@ import {
 } from '@angular-devkit/schematics';
 import { existsSync, readFileSync } from 'fs';
 import { parse, stringify } from 'comment-json';
-import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
+import { inPlaceSortByKeys, normalizeToKebabOrSnakeCase } from '../../utils';
 import {
   DEFAULT_APPS_PATH,
   DEFAULT_APP_NAME,
@@ -150,6 +150,8 @@ function updateTsConfig() {
         if (!tsconfig.compilerOptions.paths) {
           tsconfig.compilerOptions.paths = {};
         }
+
+        inPlaceSortByKeys(tsconfig.compilerOptions.paths);
       },
     );
   };
@@ -324,6 +326,8 @@ function addAppsToCliOptions(
           );
         }
         optionsFile.projects[projectName] = project;
+
+        inPlaceSortByKeys(optionsFile.projects);
       },
     );
   };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './name.parser';
 export * from './path.solver';
 export * from './source-root.helpers';
 export * from './formatting';
+export * from './object-sorting';

--- a/src/utils/object-sorting.ts
+++ b/src/utils/object-sorting.ts
@@ -1,0 +1,17 @@
+/**
+ * In-place sort object entities by their keys so that it can be serialized to json with sorted order.
+ * @param object
+ * @returns The original object with modified entities order.
+ */
+export function inPlaceSortByKeys(object: Record<string, any>): Record<string, any> {
+  const sorted: Record<string, any> = {};
+
+  const keys = Object.keys(object);
+  keys.sort();
+  for (const key of keys) {
+    sorted[key] = object[key];
+    delete object[key];
+  }
+
+  return Object.assign(object, sorted);
+}

--- a/test/utils/object-sorting.test.ts
+++ b/test/utils/object-sorting.test.ts
@@ -1,0 +1,14 @@
+import { inPlaceSortByKeys } from '../../src/utils/object-sorting';
+
+
+describe('inPlaceSortByKeys', () => {
+  it('should in-place sort the entities by their keys', () => {
+    const input = { z: 'z', b: 'b', c: 'c', a: 'a', };
+    expect(Object.keys(input)).toEqual(['z', 'b', 'c', 'a']);
+
+    const got = inPlaceSortByKeys(input);
+
+    expect(got).toBe(input); // Same object
+    expect(Object.keys(got)).toEqual(['a', 'b', 'c', 'z']);
+  })
+})


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1956


## What is the new behavior?

Sort library name and sub app names in:
- `projects` of the `nest-cli.json`
- `compilerOptions.path` of the `tsconfig.json`
- `jest.moduleNameMapper` of the `package.json`

to reduce git merge conflicts

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
