### PR TITLE
chore: update typescript compiler target to ES2023

### DIFF
--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
+    "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",

--- a/src/lib/library/files/js/jsconfig.json
+++ b/src/lib/library/files/js/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2023",
     "experimentalDecorators": true
   },
   "exclude": [

--- a/src/lib/sub-app/files/js/jsconfig.json
+++ b/src/lib/sub-app/files/js/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2023",
       "experimentalDecorators": true
   },
   "exclude": [

--- a/src/lib/sub-app/workspace/js/jsconfig.json
+++ b/src/lib/sub-app/workspace/js/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2023",
       "experimentalDecorators": true
   },
   "exclude": [

--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitThis": true,
     "noEmitOnError": true,
     "noImplicitAny": false,
-    "target": "ES2021",
+    "target": "ES2023",
     "types": [
       "node"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2021",
+    "target": "ES2023",
     "typeRoots": ["node_modules/@types"],
     "outDir": "dist",
     "declaration": true,

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2021",
+    "target": "ES2023",
     "typeRoots": ["node_modules/@types"],
     "outDir": "dist",
     "declaration": true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

Since NestJS 11 now requires Node.js v20 or higher, Typescript compiler target can be set to ES2023 safely.
(https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)

This enables usage of new features such as:
- Error cause property
- Array functions: at, findLast, findLastIndex, toSorted...
- Object.hasOwn function
etc...

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No