### PR TITLE
fix: remove unused `swc` dependencies from `ts` project template #2073

### DIFF
--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -32,8 +32,6 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
-    "@swc/cli": "^0.7.0",
-    "@swc/core": "^1.10.7",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",


### PR DESCRIPTION
## Summary
This PR removes SWC-related dependencies (@swc/cli, @swc/core) from the default project template as they're included but not configured, causing confusion and increasing the package size unnecessarily.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Default NestJS project template includes unused SWC dependencies (`@swc/cli`, `@swc/core`) that aren't configured in the project.

Issue Number: #2073 

## What is the new behavior?
Removed unused SWC dependencies from the TypeScript project template.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
