### PR TITLE
fix: default e2e tests 

### DIFF
--- a/src/lib/application/files/ts/test/app.e2e-__specFileSuffix__.ts
+++ b/src/lib/application/files/ts/test/app.e2e-__specFileSuffix__.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently in new nestjs app, created via `npx @nestjs/cli new` the script `npm run test:e2e` fails after changes in #2142

```
> broken@0.0.1 test:e2e
> jest --config ./test/jest-e2e.json

 FAIL  test/app.e2e-spec.ts
  AppController (e2e)
    ✕ / (GET) (44 ms)

  ● AppController (e2e) › / (GET)

    TypeError: request is not a function

      18 |
      19 |   it('/ (GET)', () => {
    > 20 |     return request(app.getHttpServer())
         |            ^
      21 |       .get('/')
      22 |       .expect(200)
      23 |       .expect('Hello World!');

      at Object.<anonymous> (app.e2e-spec.ts:20:12)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        0.403 s
Ran all test suites.
```

## What is the new behavior?

`npm run test:e2e` and `npm run lint` work


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There is also floating promise warning after running lint, just fyi:

<img width="579" height="250" alt="image" src="https://github.com/user-attachments/assets/5d4cb812-8222-473d-8f16-0ced92f6d922" />

```
/private/tmp/broken/src/main.ts
  8:1  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
```
