### PR TITLE
fix: unify modulenamemapper format consistency

### DIFF
--- a/src/lib/library/library.factory.test.ts
+++ b/src/lib/library/library.factory.test.ts
@@ -104,7 +104,7 @@ describe('Library Factory', () => {
     let tree: Tree = new EmptyTree();
     tree.create('/package.json', `{"name": "my-pacakge","version": "1.0.0","jest": {}}`);
     tree.create('/tsconfig.json', `{compilerOptions: {}}`);
-
+    tree.create('/test/jest-e2e.json', `{}`);
 
     for (const o of options) {
       tree = await runner.runSchematic('library', o, tree);
@@ -117,6 +117,24 @@ describe('Library Factory', () => {
       '^app/b(|/.*)$',
       '^app/c(|/.*)$'
     ]); // Sorted jest.moduleNameMapper by keys
+    expect(moduleNameMapper).toEqual({
+      '^app/a(|/.*)$': '<rootDir>/libs/a/src/$1',
+      '^app/b(|/.*)$': '<rootDir>/libs/b/src/$1',
+      '^app/c(|/.*)$': '<rootDir>/libs/c/src/$1'
+    }); // Check package.json moduleNameMapper values
+
+    const jestE2EJson = tree.readJson('/test/jest-e2e.json');
+    const e2eModuleNameMapper = jestE2EJson['moduleNameMapper'];
+    expect(Object.keys(e2eModuleNameMapper)).toEqual([
+      '^app/a(|/.*)$',
+      '^app/b(|/.*)$',
+      '^app/c(|/.*)$'
+    ]); // Sorted jest-e2e.json moduleNameMapper by keys
+    expect(e2eModuleNameMapper).toEqual({
+      '^app/a(|/.*)$': '<rootDir>/../libs/a/src/$1',
+      '^app/b(|/.*)$': '<rootDir>/../libs/b/src/$1',
+      '^app/c(|/.*)$': '<rootDir>/../libs/c/src/$1'
+    }); // Check jest-e2e.json moduleNameMapper values with different root path
 
     const tsConfigJson = tree.readJson('/tsconfig.json');
     const paths = tsConfigJson['compilerOptions']['paths'];

--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -13,7 +13,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { parse } from 'jsonc-parser';
-import { inPlaceSortByKeys, normalizeToKebabOrSnakeCase } from '../../utils';
+import { createModuleNameMapper, inPlaceSortByKeys, normalizeToKebabOrSnakeCase } from '../../utils';
 import {
   DEFAULT_LANGUAGE,
   DEFAULT_LIB_PATH,
@@ -133,9 +133,9 @@ function updateJestConfig(
   if (!jestOptions.moduleNameMapper) {
     jestOptions.moduleNameMapper = {};
   }
-  const packageKeyRegex = '^' + packageKey + '(|/.*)$';
   const packageRoot = join('<rootDir>' as Path, distRoot);
-  jestOptions.moduleNameMapper[packageKeyRegex] = join(packageRoot, '$1');
+  const newMapper = createModuleNameMapper(packageKey, packageRoot);
+  Object.assign(jestOptions.moduleNameMapper, newMapper);
 
   inPlaceSortByKeys(jestOptions.moduleNameMapper);
 }
@@ -181,10 +181,9 @@ function updateJestEndToEnd(options: LibraryOptions) {
         if (!jestOptions.moduleNameMapper) {
           jestOptions.moduleNameMapper = {};
         }
-        const deepPackagePath = packageKey + '/(.*)';
         const packageRoot = '<rootDir>/../' + distRoot;
-        jestOptions.moduleNameMapper[deepPackagePath] = packageRoot + '/$1';
-        jestOptions.moduleNameMapper[packageKey] = packageRoot;
+        const newMapper = createModuleNameMapper(packageKey, packageRoot);
+        Object.assign(jestOptions.moduleNameMapper, newMapper);
 
         inPlaceSortByKeys(jestOptions.moduleNameMapper);
       },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,4 +7,5 @@ export * from './name.parser';
 export * from './path.solver';
 export * from './source-root.helpers';
 export * from './formatting';
+export * from './jest-module-mapper';
 export * from './object-sorting';

--- a/src/utils/jest-module-mapper.ts
+++ b/src/utils/jest-module-mapper.ts
@@ -1,0 +1,20 @@
+/**
+ * Creates a unified moduleNameMapper configuration for Jest.
+ * Uses the correct format from package.json: ^packageKey(|/.*)$ pattern
+ * @param packageKey The package key (e.g., '@app/hello')
+ * @param packageRoot The package root path (e.g., '<rootDir>/libs/hello/src')
+ * @returns Record containing moduleNameMapper entries
+ */
+export function createModuleNameMapper(
+  packageKey: string,
+  packageRoot: string,
+): Record<string, string> {
+  const moduleNameMapper: Record<string, string> = {};
+
+  // Use the correct format from package.json: ^packageKey(|/.*)$
+  // This handles both exact match (@app/hello) and sub-paths (@app/hello/submodule)
+  const packageKeyRegex = '^' + packageKey + '(|/.*)$';
+  moduleNameMapper[packageKeyRegex] = packageRoot + '/$1';
+
+  return moduleNameMapper;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: https://github.com/nestjs/nest-cli/issues/3144

When creating a library, `package.json` and `test/jest-e2e.json` generate different moduleNameMapper formats:
- package.json: `^@app/hello(|/.*)$` → `<rootDir>/libs/hello/src/$1`
- jest-e2e.json: `@app/hello/(.*)` and `@app/hello` → `<rootDir>/../libs/hello/src/$1`

This inconsistency causes e2e tests to fail when importing enum exports from libraries.

## What is the new behavior?

Both `package.json` and `jest-e2e.json` now use the consistent `^packageKey(|/.*)$` format:
- package.json: `^@app/hello(|/.*)$` → `<rootDir>/libs/hello/src/$1`
- jest-e2e.json: `^@app/hello(|/.*)$` → `<rootDir>/../libs/hello/src/$1`

Added unified `createModuleNameMapper` utility function to ensure consistency.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

This fix resolves the moduleNameMapper inconsistency that prevented e2e tests from properly resolving library enum imports.