### PR TITLE
refactor(eslint.config.mjs): configure prettier endOfLine to 'auto' for cross-platform compat…

### DIFF
--- a/src/lib/application/files/ts/eslint.config.mjs
+++ b/src/lib/application/files/ts/eslint.config.mjs
@@ -28,7 +28,8 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      "prettier/prettier": ["error", { endOfLine: "auto" }],
     },
   },
 );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Windows developers encounter ESLint/Prettier errors due to CRLF line endings, while the repo expects LF.

Issue Number: N/A


## What is the new behavior?
Setting endOfLine: 'auto' allows Prettier to normalize based on detected format.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No
