### PR TITLE
chore(tsconfig): replace deprecated baseUrl with paths mapping

### DIFF
--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -13,7 +13,9 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
Replaces the deprecated `baseUrl: "./"` with the modern `paths` configuration.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The baseUrl option is being deprecated in favor of manually specifying a custom prefix for paths. 

Issue Number: N/A


## What is the new behavior?
This maintains the same module resolution behavior (`./src/*` is mapped to `@/*`) while using the non-deprecated property.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
