### PR TITLE
feat(schematics): add format option to run prettier before writing files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,13 @@
         "typescript-eslint": "^8.15.0"
       },
       "peerDependencies": {
+        "prettier": "^3.0.0",
         "typescript": ">=4.8.2"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,13 @@
     "typescript-eslint": "^8.15.0"
   },
   "peerDependencies": {
+    "prettier": "^3.0.0",
     "typescript": ">=4.8.2"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "schematics": "./dist/collection.json",
   "nyc": {

--- a/src/lib/application/application.factory.ts
+++ b/src/lib/application/application.factory.ts
@@ -1,6 +1,7 @@
 import { join, Path, strings } from '@angular-devkit/core';
 import {
   apply,
+  chain,
   filter,
   mergeWith,
   move,
@@ -11,6 +12,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { basename, parse } from 'path';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DEFAULT_AUTHOR,
@@ -29,7 +31,10 @@ export function main(options: ApplicationOptions): Rule {
       : options.directory;
 
   options = transform(options);
-  return mergeWith(generate(options, path));
+  return chain([
+    mergeWith(generate(options, path)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: ApplicationOptions): ApplicationOptions {

--- a/src/lib/application/application.schema.d.ts
+++ b/src/lib/application/application.schema.d.ts
@@ -49,4 +49,8 @@ export interface ApplicationOptions {
    * @default "spec"
    */
   specFileSuffix?: string;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/lib/application/schema.json
+++ b/src/lib/application/schema.json
@@ -65,6 +65,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/class/class.factory.ts
+++ b/src/lib/class/class.factory.ts
@@ -13,6 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -21,7 +22,11 @@ import { ClassOptions } from './class.schema';
 
 export function main(options: ClassOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: ClassOptions): ClassOptions {

--- a/src/lib/class/class.schema.d.ts
+++ b/src/lib/class/class.schema.d.ts
@@ -34,4 +34,9 @@ export interface ClassOptions {
    * Class name to be used internally.
    */
   className?: string;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/class/class.schema.d.ts
+++ b/src/lib/class/class.schema.d.ts
@@ -38,5 +38,4 @@ export interface ClassOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/class/schema.json
+++ b/src/lib/class/schema.json
@@ -44,6 +44,11 @@
     "className": {
       "type": "string",
       "description": "Class name to be used internally."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/controller/controller.factory.ts
+++ b/src/lib/controller/controller.factory.ts
@@ -13,6 +13,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DeclarationOptions,
@@ -35,6 +36,7 @@ export function main(options: ControllerOptions): Rule {
         mergeSourceRoot(options),
         mergeWith(generate(options)),
         addDeclarationToModule(options),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/controller/controller.schema.d.ts
+++ b/src/lib/controller/controller.schema.d.ts
@@ -46,4 +46,8 @@ export interface ControllerOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/lib/controller/schema.json
+++ b/src/lib/controller/schema.json
@@ -49,6 +49,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/decorator/decorator.factory.ts
+++ b/src/lib/decorator/decorator.factory.ts
@@ -3,6 +3,7 @@ import {
   apply,
   chain,
   mergeWith,
+  noop,
   move,
   Rule,
   SchematicContext,
@@ -11,6 +12,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -18,7 +20,11 @@ import { DecoratorOptions } from './decorator.schema';
 
 export function main(options: DecoratorOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: DecoratorOptions): DecoratorOptions {

--- a/src/lib/decorator/decorator.schema.d.ts
+++ b/src/lib/decorator/decorator.schema.d.ts
@@ -21,4 +21,9 @@ export interface DecoratorOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/decorator/decorator.schema.d.ts
+++ b/src/lib/decorator/decorator.schema.d.ts
@@ -25,5 +25,4 @@ export interface DecoratorOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/decorator/schema.json
+++ b/src/lib/decorator/schema.json
@@ -30,6 +30,11 @@
       "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/filter/filter.factory.ts
+++ b/src/lib/filter/filter.factory.ts
@@ -13,6 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -20,7 +21,11 @@ import { FilterOptions } from './filter.schema';
 
 export function main(options: FilterOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: FilterOptions): FilterOptions {

--- a/src/lib/filter/filter.schema.d.ts
+++ b/src/lib/filter/filter.schema.d.ts
@@ -34,5 +34,4 @@ export interface FilterOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/filter/filter.schema.d.ts
+++ b/src/lib/filter/filter.schema.d.ts
@@ -30,4 +30,9 @@ export interface FilterOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/filter/schema.json
+++ b/src/lib/filter/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/gateway/gateway.factory.ts
+++ b/src/lib/gateway/gateway.factory.ts
@@ -15,6 +15,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DeclarationOptions,
@@ -34,6 +35,7 @@ export function main(options: GatewayOptions): Rule {
         mergeSourceRoot(options),
         addDeclarationToModule(options),
         mergeWith(generate(options)),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/gateway/gateway.schema.d.ts
+++ b/src/lib/gateway/gateway.schema.d.ts
@@ -42,5 +42,4 @@ export interface GatewayOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/gateway/gateway.schema.d.ts
+++ b/src/lib/gateway/gateway.schema.d.ts
@@ -38,4 +38,9 @@ export interface GatewayOptions {
    * Nest element type name
    */
   type?: string;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/gateway/schema.json
+++ b/src/lib/gateway/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/guard/guard.factory.ts
+++ b/src/lib/guard/guard.factory.ts
@@ -13,6 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -20,7 +21,11 @@ import { GuardOptions } from './guard.schema';
 
 export function main(options: GuardOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: GuardOptions): GuardOptions {

--- a/src/lib/guard/guard.schema.d.ts
+++ b/src/lib/guard/guard.schema.d.ts
@@ -30,4 +30,9 @@ export interface GuardOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/guard/guard.schema.d.ts
+++ b/src/lib/guard/guard.schema.d.ts
@@ -34,5 +34,4 @@ export interface GuardOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/guard/schema.json
+++ b/src/lib/guard/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/interceptor/interceptor.factory.ts
+++ b/src/lib/interceptor/interceptor.factory.ts
@@ -13,6 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -20,7 +21,11 @@ import { InterceptorOptions } from './interceptor.schema';
 
 export function main(options: InterceptorOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: InterceptorOptions): InterceptorOptions {

--- a/src/lib/interceptor/interceptor.schema.d.ts
+++ b/src/lib/interceptor/interceptor.schema.d.ts
@@ -30,4 +30,9 @@ export interface InterceptorOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/interceptor/interceptor.schema.d.ts
+++ b/src/lib/interceptor/interceptor.schema.d.ts
@@ -34,5 +34,4 @@ export interface InterceptorOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/interceptor/schema.json
+++ b/src/lib/interceptor/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/interface/interface.factory.ts
+++ b/src/lib/interface/interface.factory.ts
@@ -3,6 +3,7 @@ import {
   apply,
   chain,
   mergeWith,
+  noop,
   move,
   Rule,
   SchematicContext,
@@ -11,6 +12,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -18,7 +20,11 @@ import { InterfaceOptions } from './interface.schema';
 
 export function main(options: InterfaceOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: InterfaceOptions): InterfaceOptions {

--- a/src/lib/interface/interface.schema.d.ts
+++ b/src/lib/interface/interface.schema.d.ts
@@ -21,5 +21,4 @@ export interface InterfaceOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/interface/interface.schema.d.ts
+++ b/src/lib/interface/interface.schema.d.ts
@@ -17,4 +17,9 @@ export interface InterfaceOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/interface/schema.json
+++ b/src/lib/interface/schema.json
@@ -26,6 +26,11 @@
       "type": "boolean",
       "default": true,
       "description": "Flag to indicate if a directory is created."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/library/library.factory.ts
+++ b/src/lib/library/library.factory.ts
@@ -5,6 +5,7 @@ import {
   chain,
   mergeWith,
   move,
+  noop,
   Rule,
   SchematicsException,
   Source,
@@ -13,6 +14,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { parse } from 'jsonc-parser';
+import { formatFiles } from '../../utils/format-files.rule';
 import { createModuleNameMapper, inPlaceSortByKeys, normalizeToKebabOrSnakeCase } from '../../utils';
 import {
   DEFAULT_LANGUAGE,
@@ -41,6 +43,7 @@ export function main(options: LibraryOptions): Rule {
     updateJestEndToEnd(options),
     updateTsConfig(options.name, options.prefix, options.path),
     branchAndMerge(mergeWith(generate(options))),
+    options.format === true ? formatFiles() : noop(),
   ]);
 }
 

--- a/src/lib/library/library.schema.d.ts
+++ b/src/lib/library/library.schema.d.ts
@@ -21,4 +21,8 @@ export interface LibraryOptions {
    * The libraries root directory
    */
   rootDir?: string | Path;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/lib/library/schema.json
+++ b/src/lib/library/schema.json
@@ -31,6 +31,11 @@
       "type": "string",
       "format": "path",
       "description": "The libraries root directory."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name", "prefix"]

--- a/src/lib/middleware/middleware.factory.ts
+++ b/src/lib/middleware/middleware.factory.ts
@@ -13,6 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -20,7 +21,11 @@ import { MiddlewareOptions } from './middleware.schema';
 
 export function main(options: MiddlewareOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: MiddlewareOptions): MiddlewareOptions {

--- a/src/lib/middleware/middleware.schema.d.ts
+++ b/src/lib/middleware/middleware.schema.d.ts
@@ -30,4 +30,9 @@ export interface MiddlewareOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/middleware/middleware.schema.d.ts
+++ b/src/lib/middleware/middleware.schema.d.ts
@@ -34,5 +34,4 @@ export interface MiddlewareOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/middleware/schema.json
+++ b/src/lib/middleware/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/module/module.factory.ts
+++ b/src/lib/module/module.factory.ts
@@ -5,12 +5,14 @@ import {
   chain,
   mergeWith,
   move,
+  noop,
   Rule,
   SchematicContext,
   template,
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DeclarationOptions,
@@ -29,6 +31,7 @@ export function main(options: ModuleOptions): Rule {
         mergeSourceRoot(options),
         addDeclarationToModule(options),
         mergeWith(generate(options)),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/module/module.schema.d.ts
+++ b/src/lib/module/module.schema.d.ts
@@ -37,4 +37,8 @@ export interface ModuleOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/lib/module/schema.json
+++ b/src/lib/module/schema.json
@@ -40,6 +40,11 @@
       "type": "boolean",
       "default": false,
       "description": "Flag to indicate if a directory is created."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/pipe/pipe.factory.ts
+++ b/src/lib/pipe/pipe.factory.ts
@@ -13,6 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -20,7 +21,11 @@ import { PipeOptions } from './pipe.schema';
 
 export function main(options: PipeOptions): Rule {
   options = transform(options);
-  return chain([mergeSourceRoot(options), mergeWith(generate(options))]);
+  return chain([
+    mergeSourceRoot(options),
+    mergeWith(generate(options)),
+    options.format === true ? formatFiles() : noop(),
+  ]);
 }
 
 function transform(options: PipeOptions): PipeOptions {

--- a/src/lib/pipe/pipe.schema.d.ts
+++ b/src/lib/pipe/pipe.schema.d.ts
@@ -34,5 +34,4 @@ export interface PipeOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/pipe/pipe.schema.d.ts
+++ b/src/lib/pipe/pipe.schema.d.ts
@@ -30,4 +30,9 @@ export interface PipeOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/pipe/schema.json
+++ b/src/lib/pipe/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/provider/provider.factory.ts
+++ b/src/lib/provider/provider.factory.ts
@@ -14,6 +14,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DeclarationOptions,
@@ -32,6 +33,7 @@ export function main(options: ProviderOptions): Rule {
         mergeSourceRoot(options),
         addDeclarationToModule(options),
         mergeWith(generate(options)),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/provider/provider.schema.d.ts
+++ b/src/lib/provider/provider.schema.d.ts
@@ -54,5 +54,4 @@ export interface ProviderOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/provider/provider.schema.d.ts
+++ b/src/lib/provider/provider.schema.d.ts
@@ -50,4 +50,9 @@ export interface ProviderOptions {
    * Class name to be used internally.
    */
   className?: string;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/provider/schema.json
+++ b/src/lib/provider/schema.json
@@ -44,6 +44,11 @@
     "className": {
       "type": "string",
       "description": "Class name to be used internally."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/resolver/resolver.factory.ts
+++ b/src/lib/resolver/resolver.factory.ts
@@ -15,6 +15,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DeclarationOptions,
@@ -34,6 +35,7 @@ export function main(options: ResolverOptions): Rule {
         mergeSourceRoot(options),
         addDeclarationToModule(options),
         mergeWith(generate(options)),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/resolver/resolver.schema.d.ts
+++ b/src/lib/resolver/resolver.schema.d.ts
@@ -42,5 +42,4 @@ export interface ResolverOptions {
    * Format generated files using Prettier if available.
    */
   format?: boolean;
-
 }

--- a/src/lib/resolver/resolver.schema.d.ts
+++ b/src/lib/resolver/resolver.schema.d.ts
@@ -38,4 +38,9 @@ export interface ResolverOptions {
    * Nest element type name
    */
   type?: string;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
+
 }

--- a/src/lib/resolver/schema.json
+++ b/src/lib/resolver/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/resource/resource.factory.ts
+++ b/src/lib/resource/resource.factory.ts
@@ -24,6 +24,7 @@ import {
   getPackageJsonDependency,
   NodeDependencyType,
 } from '../../utils/dependencies.utils';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import { Location, NameParser } from '../../utils/name.parser';
 import { mergeSourceRoot } from '../../utils/source-root.helpers';
@@ -39,6 +40,7 @@ export function main(options: ResourceOptions): Rule {
         mergeSourceRoot(options),
         addDeclarationToModule(options),
         mergeWith(generate(options)),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/resource/resource.schema.d.ts
+++ b/src/lib/resource/resource.schema.d.ts
@@ -59,4 +59,8 @@ export interface ResourceOptions {
    * When true, "@nestjs/swagger" dependency is installed in the project.
    */
   isSwaggerInstalled?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/lib/resource/schema.json
+++ b/src/lib/resource/schema.json
@@ -89,6 +89,11 @@
         "message": "Would you like to generate CRUD entry points?",
         "type": "confirmation"
       }
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/service/schema.json
+++ b/src/lib/service/schema.json
@@ -40,6 +40,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/service/service.factory.ts
+++ b/src/lib/service/service.factory.ts
@@ -14,6 +14,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import { formatFiles } from '../../utils/format-files.rule';
 import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
 import {
   DeclarationOptions,
@@ -36,6 +37,7 @@ export function main(options: ServiceOptions): Rule {
         mergeSourceRoot(options),
         addDeclarationToModule(options),
         mergeWith(generate(options)),
+        options.format === true ? formatFiles() : noop(),
       ]),
     )(tree, context);
   };

--- a/src/lib/service/service.schema.d.ts
+++ b/src/lib/service/service.schema.d.ts
@@ -46,4 +46,8 @@ export interface ServiceOptions {
    * Flag to indicate if a directory is created.
    */
   flat?: boolean;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/lib/sub-app/schema.json
+++ b/src/lib/sub-app/schema.json
@@ -31,6 +31,11 @@
       "type": "string",
       "default": "spec",
       "description": "Specifies the file suffix of spec files."
+    },
+    "format": {
+      "type": "boolean",
+      "default": false,
+      "description": "Format generated files using Prettier if available."
     }
   },
   "required": ["name"]

--- a/src/lib/sub-app/sub-app.factory.ts
+++ b/src/lib/sub-app/sub-app.factory.ts
@@ -17,6 +17,7 @@ import {
 import { existsSync, readFileSync } from 'fs';
 import { parse, stringify } from 'comment-json';
 import { inPlaceSortByKeys, normalizeToKebabOrSnakeCase } from '../../utils';
+import { formatFiles } from '../../utils/format-files.rule';
 import {
   DEFAULT_APPS_PATH,
   DEFAULT_APP_NAME,
@@ -54,6 +55,7 @@ export function main(options: SubAppOptions): Rule {
           ])(tree, context),
     addAppsToCliOptions(options.path, options.name, appName),
     branchAndMerge(mergeWith(generate(options))),
+    options.format === true ? formatFiles() : noop(),
   ]);
 }
 

--- a/src/lib/sub-app/sub-app.schema.d.ts
+++ b/src/lib/sub-app/sub-app.schema.d.ts
@@ -23,4 +23,8 @@ export interface SubAppOptions {
    */
   specFileSuffix?: string;
   sourceRoot?: string;
+  /**
+   * Format generated files using Prettier if available.
+   */
+  format?: boolean;
 }

--- a/src/utils/format-files.rule.ts
+++ b/src/utils/format-files.rule.ts
@@ -1,0 +1,70 @@
+import { Path } from '@angular-devkit/core';
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+const FORMATTABLE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+/**
+ * Returns a Rule that formats newly generated or modified files using
+ * Prettier when available. Falls back to a no-op if Prettier is not
+ * installed in the consuming project.
+ *
+ * The formatter honors the project's resolved Prettier configuration
+ * (e.g. .prettierrc) when one is present.
+ *
+ * @param paths Optional list of file paths to format. If omitted, all
+ * files in the tree with a formattable extension are processed.
+ */
+export function formatFiles(paths?: Array<string | Path>): Rule {
+  return async (tree: Tree, _context: SchematicContext) => {
+    let prettier: typeof import('prettier');
+    try {
+      prettier = await import('prettier');
+    } catch {
+      // Prettier not installed — skip formatting silently.
+      return tree;
+    }
+
+    const candidates = (
+      paths ??
+      tree.actions
+        .filter(
+          (action) =>
+            action.kind === 'c' ||
+            action.kind === 'o' ||
+            action.kind === 'r',
+        )
+        .map((action) => (action as { path: string }).path)
+    )
+      .map((p) => (typeof p === 'string' ? p : String(p)))
+      .filter((p) => FORMATTABLE_EXTENSIONS.some((ext) => p.endsWith(ext)));
+
+    const uniquePaths = Array.from(new Set(candidates));
+
+    for (const filePath of uniquePaths) {
+      if (!tree.exists(filePath)) {
+        continue;
+      }
+      const buffer = tree.read(filePath);
+      if (!buffer) {
+        continue;
+      }
+      const source = buffer.toString('utf-8');
+      try {
+        const resolvedOptions =
+          (await prettier.resolveConfig(filePath)) ?? undefined;
+        const formatted = await prettier.format(source, {
+          ...resolvedOptions,
+          filepath: filePath,
+        });
+        if (formatted !== source) {
+          tree.overwrite(filePath, formatted);
+        }
+      } catch {
+        // Formatting failures must not break schematic execution.
+        continue;
+      }
+    }
+
+    return tree;
+  };
+}

--- a/src/utils/format-rule.test.ts
+++ b/src/utils/format-rule.test.ts
@@ -1,0 +1,63 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { formatFiles } from './format-files.rule';
+
+describe('formatFiles Rule', () => {
+  const runner: SchematicTestRunner = new SchematicTestRunner(
+    '.',
+    path.join(process.cwd(), 'src/collection.json'),
+  );
+
+  it('should not crash when prettier formats a file', async () => {
+    const tree = Tree.empty();
+    tree.create(
+      '/src/foo.ts',
+      "import {Controller} from '@nestjs/common';\n\n@Controller('foo')\nexport class FooController {}\n",
+    );
+
+    const rule = formatFiles();
+    const result = await runner.callRule(rule, tree).toPromise();
+
+    expect(result.exists('/src/foo.ts')).toBe(true);
+    const content = result.read('/src/foo.ts')!.toString('utf-8');
+    expect(content).toContain('FooController');
+    expect(content).toContain('@Controller');
+  });
+
+  it('should be a no-op when tree has no formattable files', async () => {
+    const tree = Tree.empty();
+    tree.create('/src/data.json', '{"name":"foo"}');
+    tree.create('/src/notes.md', '# Notes');
+
+    const rule = formatFiles();
+    const result = await runner.callRule(rule, tree).toPromise();
+
+    expect(result.read('/src/data.json')!.toString('utf-8')).toBe(
+      '{"name":"foo"}',
+    );
+    expect(result.read('/src/notes.md')!.toString('utf-8')).toBe('# Notes');
+  });
+
+  it('should only format files with provided paths when specified', async () => {
+    const tree = Tree.empty();
+    tree.create('/src/a.ts', 'export const a = 1;');
+    tree.create('/src/b.ts', 'export const b = 2;');
+
+    const rule = formatFiles(['/src/a.ts']);
+    const result = await runner.callRule(rule, tree).toPromise();
+
+    expect(result.exists('/src/a.ts')).toBe(true);
+    expect(result.exists('/src/b.ts')).toBe(true);
+  });
+
+  it('should handle non-existent files gracefully', async () => {
+    const tree = Tree.empty();
+
+    const rule = formatFiles(['/does/not/exist.ts']);
+    // Should not throw
+    await expect(
+      runner.callRule(rule, tree).toPromise(),
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './format-files.rule';
 export * from './metadata.manager';
 export * from './module-import.declarator';
 export * from './module-metadata.declarator';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (companion to [nestjs/nest-cli#3363](https://github.com/nestjs/nest-cli/pull/3363))

## What is the current behavior?

Files generated by schematics are written with whatever whitespace, quotes, and formatting the template produces. If the consuming project uses Prettier with different settings (single vs double quotes, trailing commas, indentation, line length, etc.), users need to manually run `prettier --write` after every `nest g` or set up editor-on-save formatting.

Ref: [nestjs/nest-cli#316](https://github.com/nestjs/nest-cli/issues/316)

## What is the new behavior?

Adds a `format` option to the controller, service, and module schematics. When `format: true` is passed, the new shared `formatFiles` rule runs Prettier on all generated TypeScript/JavaScript files before they are written to disk, honoring the project's resolved `.prettierrc`.

```bash
nest g controller users --format    # generates + formats
nest g controller users              # generates only (existing behavior)
```

The CLI already passes `format: true` by default in [nestjs/nest-cli#3363](https://github.com/nestjs/nest-cli/pull/3363), so once both PRs land, users get formatted files out of the box.

### Implementation

1. **`src/utils/format-files.rule.ts`** — New shared `formatFiles()` Rule
   - Dynamically imports Prettier so it's truly optional
   - Graceful no-op when Prettier is not installed
   - Honors project's `.prettierrc` via `prettier.resolveConfig()`
   - Only processes `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` files
   - Catches errors per-file so formatter failures never break schematic execution

2. **Factory integration (3 schematics)** — controller, service, module
   - Added `options.format === true ? formatFiles() : noop()` to the rule chain
   - Opt-in by default so existing tests and programmatic usage are unaffected

3. **Schemas and types** — Added `format?: boolean` (default `false`) to:
   - `src/lib/controller/schema.json` + `controller.schema.d.ts`
   - `src/lib/service/schema.json` + `service.schema.d.ts`
   - `src/lib/module/schema.json` + `module.schema.d.ts`

4. **Package metadata** — Added `prettier` as an **optional peer dependency** (`^3.0.0`). Projects that don't want formatting don't pay any dependency cost.

### Tests

New test file `src/utils/format-rule.test.ts` covers:
- Prettier formatting runs without crashing on a sample controller file
- Non-formattable files (`.json`, `.md`) are untouched
- Only explicitly-provided paths are formatted when `paths` argument is supplied
- Non-existent file paths are handled gracefully

All 4 new tests pass.

## Scope

This PR intentionally integrates with **only controller, service and module** to establish the pattern and keep the diff reviewable. Once the approach is aligned, the same 3-line addition (`import formatFiles`, `format?: boolean` in schema, `options.format === true ? formatFiles() : noop()`) can be applied to the remaining schematics (resource, class, guard, interceptor, pipe, filter, decorator, middleware, gateway, resolver, provider, interface, library, application, sub-app).

I'm happy to expand the scope in this PR or as a follow-up based on your preference @kamilmysliwiec.