### PR TITLE
fix(schematics): add jest types to app tsconfig

### DIFF
--- a/src/lib/application/application.factory.test.ts
+++ b/src/lib/application/application.factory.test.ts
@@ -46,6 +46,14 @@ describe('Application Factory', () => {
       ).toMatchObject({
         name: 'project',
       });
+
+      expect(
+        JSON.parse(tree.readContent('/project/tsconfig.json')),
+      ).toMatchObject({
+        compilerOptions: {
+          types: ['node', 'jest'],
+        },
+      });
     });
     it('should manage name with dots in it', async () => {
       const options: ApplicationOptions = {

--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -11,6 +11,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "target": "ES2023",
+    "types": ["node", "jest"],
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Generated TypeScript applications include Jest test files and Jest dependencies, but the generated `tsconfig.json` does not explicitly include Jest ambient types. This can leave generated test files without Jest globals in editors or type-checking setups that rely on explicit `compilerOptions.types`.

Issue Number: Fixes #2357


## What is the new behavior?
The TypeScript application template now includes `compilerOptions.types` with `node` and `jest`, so generated apps include both runtime Node globals and Jest test globals.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Validated with:

```bash
npm test -- src/lib/application/application.factory.test.ts --runTestsByPath
npm run build
npm exec -- prettier --check src/lib/application/application.factory.test.ts
git diff --check
```

`npm run lint -- --no-warn-ignored` currently reports pre-existing unrelated errors in `src/lib/client-app/angular/angular.factory.ts`, `src/lib/library/library.factory.ts`, `src/lib/sub-app/sub-app.factory.ts`, and `src/utils/format-files.rule.ts`. The changed test file is ignored by the current ESLint config, and the changed template JSON contains EJS placeholders that Prettier cannot parse directly.
