### PR TITLE
fix(application): use void when invoking bootstrap()

### DIFF
--- a/src/lib/application/files/ts-esm/src/main.ts
+++ b/src/lib/application/files/ts-esm/src/main.ts
@@ -5,4 +5,4 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.listen(process.env.PORT ?? 3000);
 }
-await bootstrap();
+void bootstrap();


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (not applicable)
- [ ] Docs have been added / updated (not applicable)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## What is the current behavior?

The generated `main.ts` template invokes `bootstrap()` without handling the returned promise:

```ts
await bootstrap();