### PR TITLE
feat(schematics): allow configuring application hostname

### DIFF
--- a/src/lib/application/files/js/src/main.js
+++ b/src/lib/application/files/js/src/main.js
@@ -5,6 +5,12 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule<% if (observe) { %>, {
     instrument: ObserveInstrument,
   }<% } %>);
-  await app.listen(process.env.PORT || 3000);
+  const port = process.env.PORT || 3000;
+
+  if (process.env.HOST) {
+    await app.listen(port, process.env.HOST);
+  } else {
+    await app.listen(port);
+  }
 }
 bootstrap();

--- a/src/lib/application/files/ts-esm/src/main.ts
+++ b/src/lib/application/files/ts-esm/src/main.ts
@@ -5,6 +5,12 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule<% if (observe) { %>, {
     instrument: ObserveInstrument,
   }<% } %>);
-  await app.listen(process.env.PORT ?? 3000);
+  const port = process.env.PORT ?? 3000;
+
+  if (process.env.HOST) {
+    await app.listen(port, process.env.HOST);
+  } else {
+    await app.listen(port);
+  }
 }
 await bootstrap();

--- a/src/lib/application/files/ts/src/main.ts
+++ b/src/lib/application/files/ts/src/main.ts
@@ -5,6 +5,12 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule<% if (observe) { %>, {
     instrument: ObserveInstrument,
   }<% } %>);
-  await app.listen(process.env.PORT ?? 3000);
+  const port = process.env.PORT ?? 3000;
+
+  if (process.env.HOST) {
+    await app.listen(port, process.env.HOST);
+  } else {
+    await app.listen(port);
+  }
 }
 bootstrap();


### PR DESCRIPTION
Allow generated NestJS applications to explicitly configure the HTTP server hostname through the HOST environment variable.

Currently, generated applications pass only the port to app.listen(), leaving the hostname unspecified. This can lead to unintuitive behavior when another application is listening on the same port but on a specific hostname.

For example:

Laravel: 127.0.0.1:8000
NestJS:  *:8000

In this situation, Node.js may allow both servers to listen without raising EADDRINUSE.

When the hostname is explicitly configured:

Laravel: 127.0.0.1:8000
NestJS: 127.0.0.1:8000

the expected EADDRINUSE error is raised.

This change allows users to configure the hostname when needed while preserving the existing behavior when HOST is not provided.

Example
PORT=8000
HOST=127.0.0.1

The generated application will use:

await app.listen(port, host);

when HOST is configured.

Testing
npm test passed
npm run lint passed
npm run typecheck passed