### PR TITLE
fix(application): set explicit rootDir in generated tsconfig

### DIFF
--- a/src/lib/application/files/js/package.json
+++ b/src/lib/application/files/js/package.json
@@ -10,9 +10,9 @@
     "format": "prettier --write \"**/*.js\"",
     "start": "babel-node index.js",
     "start:dev": "nodemon",
-    "test": "jest",
-    "test:cov": "jest --coverage",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test:cov": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
+    "test:e2e": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^12.0.1",

--- a/src/lib/application/files/ts-esm/tsconfig.json
+++ b/src/lib/application/files/ts-esm/tsconfig.json
@@ -13,6 +13,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strict": <%= strict %>,

--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -14,11 +14,11 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "oxlint src/ test/",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test:watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
+    "test:cov": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
+    "test:debug": "node --inspect-brk --experimental-vm-modules -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^12.0.1",
@@ -42,7 +42,7 @@
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.2.5",
+    "ts-jest": "^29.4.0",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -14,6 +14,7 @@
     "types": ["node", "jest"],
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strict": <%= strict %>,

--- a/test/lib/generated-project-config.test.ts
+++ b/test/lib/generated-project-config.test.ts
@@ -229,6 +229,19 @@ describe('Generated project configuration', () => {
     });
   });
 
+  describe('base tsconfig', () => {
+    it.each(['esm', 'cjs'] as const)(
+      'should set an explicit rootDir on the %s tsconfig so TS 6 does not emit TS5011',
+      async (type) => {
+        const tree = await app(type);
+        const tsconfig = JSON.parse(tree.readContent('/tsconfig.json'));
+
+        expect(tsconfig.compilerOptions.rootDir).toBe('.');
+        expect(tsconfig.compilerOptions.outDir).toBe('./dist');
+      },
+    );
+  });
+
   describe('build tsconfig', () => {
     it.each(['esm', 'cjs'] as const)(
       'should scope the %s build to src so the entry point stays at dist/main',

--- a/test/lib/generated-project-config.test.ts
+++ b/test/lib/generated-project-config.test.ts
@@ -38,6 +38,20 @@ describe('Generated project configuration', () => {
       expect(tree.readContent('/jest.config.ts')).toContain("rootDir: '.'");
     });
 
+    it('should enable Jest require(esm) for Nest 12 packages', async () => {
+      const tree = await app('cjs');
+      const packageJson = JSON.parse(tree.readContent('/package.json'));
+
+      expect(packageJson.scripts.test).toContain('--experimental-vm-modules');
+      expect(packageJson.scripts['test:cov']).toContain(
+        '--experimental-vm-modules',
+      );
+      expect(packageJson.scripts['test:e2e']).toContain(
+        '--experimental-vm-modules',
+      );
+      expect(packageJson.devDependencies['ts-jest']).toBe('^29.4.0');
+    });
+
     it('should keep the e2e jest config alongside the e2e tests', async () => {
       const tree = await app('cjs');
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Generated `tsconfig.json` sets emit options (`outDir`, `declaration`, etc.) without an explicit `rootDir`. Under TypeScript 6, `ts-jest` (with `isolatedModules`) re-infers a deeper common source directory from the spec subset and fails with TS5011. Fresh `nest new` CJS projects then fail `pnpm test:cov`.

Issue Number: nestjs/nest#17661

## What is the new behavior?

CJS and ESM application templates set `"rootDir": "."` in `compilerOptions`. `tsconfig.build.json` still pins `"rootDir": "./src"`, so `nest build` output stays at `dist/main`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Requested by @micalevisk on nestjs/nest#17661.