### PR TITLE
fix(application): set explicit rootdir in generated tsconfig

### DIFF
--- a/src/lib/application/files/ts-esm/tsconfig.json
+++ b/src/lib/application/files/ts-esm/tsconfig.json
@@ -13,6 +13,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strict": <%= strict %>,

--- a/src/lib/application/files/ts/tsconfig.json
+++ b/src/lib/application/files/ts/tsconfig.json
@@ -14,6 +14,7 @@
     "types": ["node", "jest"],
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strict": <%= strict %>,

--- a/test/lib/generated-project-config.test.ts
+++ b/test/lib/generated-project-config.test.ts
@@ -229,6 +229,18 @@ describe('Generated project configuration', () => {
     });
   });
 
+  describe('tsconfig', () => {
+    it.each(['esm', 'cjs'] as const)(
+      'should set rootDir to "." in the %s tsconfig',
+      async (type) => {
+        const tree = await app(type);
+        const tsconfig = JSON.parse(tree.readContent('/tsconfig.json'));
+
+        expect(tsconfig.compilerOptions.rootDir).toBe('.');
+      },
+    );
+  });
+
   describe('build tsconfig', () => {
     it.each(['esm', 'cjs'] as const)(
       'should scope the %s build to src so the entry point stays at dist/main',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?

Freshly generated NestJS TypeScript projects do not explicitly define `rootDir` in their generated `tsconfig.json`.

With TypeScript 6, this can cause `TS5011` when test files are compiled because TypeScript may infer a deeper common source directory from the test inputs.

Issue Number: nestjs/nest#17661


## What is the new behavior?

The generated TypeScript `tsconfig.json` now explicitly sets:

```json
"rootDir": "."