### PR TITLE
fix(upgrade): avoid runtime ScriptTarget enum import from typescript

### DIFF
--- a/src/lib/upgrade/upgrade.utils.ts
+++ b/src/lib/upgrade/upgrade.utils.ts
@@ -1,5 +1,12 @@
 import { SchematicContext, Tree } from '@angular-devkit/schematics';
 import { parse } from 'jsonc-parser';
+import type {
+  Node,
+  ObjectLiteralElementLike,
+  ObjectLiteralExpression,
+  ScriptTarget,
+  SourceFile,
+} from 'typescript';
 import {
   createSourceFile,
   forEachChild,
@@ -7,11 +14,6 @@ import {
   isImportDeclaration,
   isNoSubstitutionTemplateLiteral,
   isStringLiteral,
-  Node,
-  ObjectLiteralElementLike,
-  ObjectLiteralExpression,
-  ScriptTarget,
-  SourceFile,
 } from 'typescript';
 import { JSONFile } from '../../utils/json-file.util.js';
 import {
@@ -231,7 +233,8 @@ export function collectSourceFiles(tree: Tree, roots: string[]): string[] {
 }
 
 export function parseSource(path: string, content: string): SourceFile {
-  return createSourceFile(path, content, ScriptTarget.Latest, true);
+  // Use 99 (ScriptTarget.Latest) to avoid runtime ScriptTarget enum export dependency
+  return createSourceFile(path, content, 99 as ScriptTarget, true);
 }
 
 export function forEachDescendant(

--- a/src/utils/metadata.manager.ts
+++ b/src/utils/metadata.manager.ts
@@ -10,10 +10,10 @@ import {
   ObjectLiteralElement,
   ObjectLiteralExpression,
   PropertyAssignment,
-  ScriptTarget,
   SourceFile,
   SyntaxKind,
 } from 'typescript';
+import type { ScriptTarget } from 'typescript';
 import { DeclarationOptions } from './module.declarator.js';
 
 /**
@@ -42,7 +42,7 @@ export class MetadataManager {
     const source: SourceFile = createSourceFile(
       'filename.ts',
       this.content,
-      ScriptTarget.ES2017,
+      4 as ScriptTarget, // ScriptTarget.ES2017
     );
     const moduleDecoratorNode = this.findFirstDecoratorMetadata(
       source,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When executing `nest upgrade` in an ESM context, Node fails at runtime with:
```
Error: The requested module 'typescript' does not provide an export named 'ScriptTarget'
```
because `ScriptTarget` was imported as a runtime named export from `'typescript'`.

Issue Number: Closes https://github.com/nestjs/nest-cli/issues/3555

## What is the new behavior?
- Changed `ScriptTarget` from a runtime value import to a type-only import (`import type { ScriptTarget } from 'typescript'`) in `src/lib/upgrade/upgrade.utils.ts` and `src/utils/metadata.manager.ts`.
- Substituted the numeric constants `99` (`ScriptTarget.Latest`) and `4` (`ScriptTarget.ES2017`) in `createSourceFile(...)` calls so that TypeScript avoids emitting a named runtime import for the enum.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
